### PR TITLE
refactor: review cleanup for upstream readiness

### DIFF
--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -59,7 +59,7 @@ pub struct VolumeConfig {
     #[schemars(skip)]
     pub rest: JsonKeyValueMap,
 }
-#[derive(JsonSchema, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Debug, Clone, PartialEq, Eq)]
 pub struct StorageConfig {
     pub name: String,
     pub key_expr: OwnedKeyExpr,
@@ -72,7 +72,7 @@ pub struct StorageConfig {
     pub replication: Option<ReplicaConfig>,
 }
 // Note: All parameters should be same for replicas, else will result on huge overhead
-#[derive(JsonSchema, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Debug, Clone, PartialEq, Eq)]
 pub struct ReplicaConfig {
     pub interval: Duration,
     pub sub_intervals: usize,
@@ -87,10 +87,10 @@ pub struct ReplicaConfig {
     /// patterns, consider increasing this value.
     /// This does NOT need to match across replicas.
     pub bloom_filter_capacity: Option<usize>,
-    /// False positive rate of the bloom filter. Must be between 0.0 (exclusive) and 1.0
-    /// (exclusive). If `None`, defaults to 0.01 (1%).
+    /// False positive rate of the bloom filter, in per-mille (1 = 0.1%, 10 = 1%, 50 = 5%).
+    /// If `None`, defaults to 10 (1%). Must be between 1 and 999 inclusive.
     /// This does NOT need to match across replicas.
-    pub bloom_filter_fp_rate: Option<f64>,
+    pub bloom_filter_fp_rate_permille: Option<u16>,
 }
 
 impl StructVersion for VolumeConfig {
@@ -170,7 +170,7 @@ impl Default for ReplicaConfig {
             // Bloom filter settings default to None, meaning the hardcoded defaults in
             // LogLatest::new will be used (capacity=4_194_304, fp_rate=0.01).
             bloom_filter_capacity: None,
-            bloom_filter_fp_rate: None,
+            bloom_filter_fp_rate_permille: None,
         }
     }
 }
@@ -672,22 +672,22 @@ impl StorageConfig {
                         )
                     }
                 }
-                if let Some(p) = s.get("bloom_filter_fp_rate") {
-                    let p = p.to_string().parse::<f64>();
+                if let Some(p) = s.get("bloom_filter_fp_rate_permille") {
+                    let p = p.to_string().parse::<u16>();
                     if let Ok(p) = p {
-                        if p <= 0.0 || p >= 1.0 {
+                        if p == 0 || p >= 1000 {
                             bail!(
-                                "Invalid value for field `bloom_filter_fp_rate` in \
-                                 `replica_config` of storage `{}`. Value must be between 0.0 \
-                                 (exclusive) and 1.0 (exclusive).",
+                                "Invalid value for field `bloom_filter_fp_rate_permille` in \
+                                 `replica_config` of storage `{}`. Value must be between 1 and \
+                                 999 (per-mille, e.g. 10 = 1%).",
                                 plugin_name
                             )
                         }
-                        replication.bloom_filter_fp_rate = Some(p);
+                        replication.bloom_filter_fp_rate_permille = Some(p);
                     } else {
                         bail!(
-                            "Invalid type for field `bloom_filter_fp_rate` in `replica_config` \
-                             of storage `{}`. Only floating point values are accepted.",
+                            "Invalid type for field `bloom_filter_fp_rate_permille` in \
+                             `replica_config` of storage `{}`. Only integer values are accepted.",
                             plugin_name
                         )
                     }

--- a/plugins/zenoh-backend-traits/src/config.test.rs
+++ b/plugins/zenoh-backend-traits/src/config.test.rs
@@ -75,7 +75,7 @@ Actual message: {err}",
             propagation_delay: Duration::from_millis(250),
             batch_size: 100,
             bloom_filter_capacity: None,
-            bloom_filter_fp_rate: None,
+            bloom_filter_fp_rate_permille: None,
         })
     );
 }
@@ -157,7 +157,7 @@ fn piece1_batch_size_zero_is_rejected() {
 fn bloom_filter_fields_default_to_none() {
     let config = ReplicaConfig::default();
     assert_eq!(config.bloom_filter_capacity, None);
-    assert_eq!(config.bloom_filter_fp_rate, None);
+    assert_eq!(config.bloom_filter_fp_rate_permille, None);
 }
 
 #[test]
@@ -175,17 +175,17 @@ fn bloom_filter_capacity_parseable_from_json() {
 }
 
 #[test]
-fn bloom_filter_fp_rate_parseable_from_json() {
+fn bloom_filter_fp_rate_permille_parseable_from_json() {
     let config = json!({
         "key_expr": "test/**",
         "volume": "memory",
         "replication": {
-            "bloom_filter_fp_rate": 0.001,
+            "bloom_filter_fp_rate_permille": 5,
         }
     });
     let storage = StorageConfig::try_from("test-plugin", "test-storage", &config).unwrap();
     let replica = storage.replication.unwrap();
-    assert_eq!(replica.bloom_filter_fp_rate, Some(0.001));
+    assert_eq!(replica.bloom_filter_fp_rate_permille, Some(5));
 }
 
 #[test]
@@ -201,36 +201,24 @@ fn bloom_filter_capacity_zero_rejected() {
 }
 
 #[test]
-fn bloom_filter_fp_rate_zero_rejected() {
+fn bloom_filter_fp_rate_permille_zero_rejected() {
     let config = json!({
         "key_expr": "test/**",
         "volume": "memory",
         "replication": {
-            "bloom_filter_fp_rate": 0.0,
+            "bloom_filter_fp_rate_permille": 0,
         }
     });
     assert!(StorageConfig::try_from("test-plugin", "test-storage", &config).is_err());
 }
 
 #[test]
-fn bloom_filter_fp_rate_one_rejected() {
+fn bloom_filter_fp_rate_permille_1000_rejected() {
     let config = json!({
         "key_expr": "test/**",
         "volume": "memory",
         "replication": {
-            "bloom_filter_fp_rate": 1.0,
-        }
-    });
-    assert!(StorageConfig::try_from("test-plugin", "test-storage", &config).is_err());
-}
-
-#[test]
-fn bloom_filter_fp_rate_above_one_rejected() {
-    let config = json!({
-        "key_expr": "test/**",
-        "volume": "memory",
-        "replication": {
-            "bloom_filter_fp_rate": 1.5,
+            "bloom_filter_fp_rate_permille": 1000,
         }
     });
     assert!(StorageConfig::try_from("test-plugin", "test-storage", &config).is_err());
@@ -246,5 +234,5 @@ fn bloom_filter_fields_absent_means_none() {
     let storage = StorageConfig::try_from("test-plugin", "test-storage", &config).unwrap();
     let replica = storage.replication.unwrap();
     assert_eq!(replica.bloom_filter_capacity, None);
-    assert_eq!(replica.bloom_filter_fp_rate, None);
+    assert_eq!(replica.bloom_filter_fp_rate_permille, None);
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replication/configuration.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/configuration.rs
@@ -35,7 +35,7 @@ use super::{
 ///
 /// Using the newtype pattern allows us to add methods to compute the time classification of
 /// events.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct Configuration {
     storage_key_expr: OwnedKeyExpr,
     prefix: Option<OwnedKeyExpr>,

--- a/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_query.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_query.rs
@@ -279,6 +279,62 @@ impl Replication {
         reply_to_query(query, reply, None).await;
     }
 
+    /// Fetches the payload associated with the given [EventMetadata] from the appropriate source.
+    ///
+    /// Returns `Some((payload, encoding))` for `Put` and `WildcardPut` actions, or `None` for
+    /// `Delete` and `WildcardDelete` actions. Returns `None` if the data cannot be found.
+    async fn fetch_event_payload(
+        &self,
+        event: &EventMetadata,
+    ) -> Option<Option<(ZBytes, Encoding)>> {
+        match &event.action {
+            Action::Delete | Action::WildcardDelete(_) => Some(None),
+            Action::Put => {
+                let stored_data = {
+                    let mut storage = self.storage_service.storage.lock().await;
+                    match storage.get(event.stripped_key.clone(), "").await {
+                        Ok(stored_data) => stored_data,
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to retrieve data associated to key < {:?} >: {e:?}",
+                                event.key_expr()
+                            );
+                            return None;
+                        }
+                    }
+                };
+
+                let requested_data = stored_data
+                    .into_iter()
+                    .find(|data| data.timestamp == *event.timestamp());
+                match requested_data {
+                    Some(data) => Some(Some((data.payload, data.encoding))),
+                    None => {
+                        tracing::debug!(
+                            "Found no data in the Storage associated to key < {:?} > with a \
+                             Timestamp equal to: {}",
+                            event.key_expr(),
+                            event.timestamp()
+                        );
+                        None
+                    }
+                }
+            }
+            Action::WildcardPut(wildcard_ke) => {
+                let wildcard_puts_guard = self.storage_service.wildcard_puts.read().await;
+
+                if let Some(update) = wildcard_puts_guard.weight_at(wildcard_ke) {
+                    Some(Some((update.payload().clone(), update.encoding().clone())))
+                } else {
+                    tracing::error!(
+                        "Ignoring Wildcard Update < {wildcard_ke} >: found no associated `Update`."
+                    );
+                    None
+                }
+            }
+        }
+    }
+
     /// Replies to the [Query] with the [EventMetadata] and [Value] identified as missing.
     ///
     /// Depending on the associated action, this method will fetch the [Value] either from the
@@ -288,72 +344,16 @@ impl Replication {
         query: &Query,
         event_to_retrieve: EventMetadata,
     ) {
-        let value = match &event_to_retrieve.action {
-            // For a Delete or WildcardDelete there is no associated `Value`.
-            Action::Delete | Action::WildcardDelete(_) => None,
-            // For a Put we need to retrieve the `Value` in the Storage.
-            Action::Put => {
-                let stored_data = {
-                    let mut storage = self.storage_service.storage.lock().await;
-                    match storage
-                        .get(event_to_retrieve.stripped_key.clone(), "")
-                        .await
-                    {
-                        Ok(stored_data) => stored_data,
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to retrieve data associated to key < {:?} >: {e:?}",
-                                event_to_retrieve.key_expr()
-                            );
-                            return;
-                        }
-                    }
-                };
-
-                let requested_data = stored_data
-                    .into_iter()
-                    .find(|data| data.timestamp == *event_to_retrieve.timestamp());
-                match requested_data {
-                    Some(data) => Some((data.payload, data.encoding)),
-                    None => {
-                        // NOTE: This is not necessarily an error. There is a possibility that the
-                        //       data associated with this specific key was updated between the time
-                        //       the [AlignmentQuery] was sent and when it is processed.
-                        //
-                        //       Hence, at the time it was "valid" but it no longer is.
-                        tracing::debug!(
-                            "Found no data in the Storage associated to key < {:?} > with a \
-                             Timestamp equal to: {}",
-                            event_to_retrieve.key_expr(),
-                            event_to_retrieve.timestamp()
-                        );
-                        return;
-                    }
-                }
-            }
-            // For a WildcardPut we need to retrieve the `Value` in the `StorageService`.
-            Action::WildcardPut(wildcard_ke) => {
-                let wildcard_puts_guard = self.storage_service.wildcard_puts.read().await;
-
-                if let Some(update) = wildcard_puts_guard.weight_at(wildcard_ke) {
-                    Some((update.payload().clone(), update.encoding().clone()))
-                } else {
-                    tracing::error!(
-                        "Ignoring Wildcard Update < {wildcard_ke} >: found no associated `Update`."
-                    );
-                    return;
-                }
-            }
+        let Some(value) = self.fetch_event_payload(&event_to_retrieve).await else {
+            return;
         };
-
         reply_to_query(query, AlignmentReply::Retrieval(event_to_retrieve), value).await;
     }
 
     /// Replies to the [Query] with a batch of [RetrievalItem]s for the given chunk of events.
     ///
-    /// For each event in the chunk, the payload is fetched from the appropriate source (Storage for
-    /// `Put`, wildcard_puts for `WildcardPut`, or `None` for `Delete`/`WildcardDelete`). All items
-    /// are then packed into a single `AlignmentReply::RetrievalBatch` reply.
+    /// For each event in the chunk, the payload is fetched via [fetch_event_payload] and packed
+    /// into a single `AlignmentReply::RetrievalBatch` reply.
     pub(crate) async fn reply_event_retrieval_batch(
         &self,
         query: &Query,
@@ -362,52 +362,8 @@ impl Replication {
         let mut items = Vec::with_capacity(events.len());
 
         for event in events {
-            let value = match &event.action {
-                Action::Delete | Action::WildcardDelete(_) => None,
-                Action::Put => {
-                    let stored_data = {
-                        let mut storage = self.storage_service.storage.lock().await;
-                        match storage.get(event.stripped_key.clone(), "").await {
-                            Ok(stored_data) => stored_data,
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to retrieve data associated to key < {:?} >: {e:?}",
-                                    event.key_expr()
-                                );
-                                continue;
-                            }
-                        }
-                    };
-
-                    let requested_data = stored_data
-                        .into_iter()
-                        .find(|data| data.timestamp == *event.timestamp());
-                    match requested_data {
-                        Some(data) => Some((data.payload, data.encoding)),
-                        None => {
-                            tracing::debug!(
-                                "Found no data in the Storage associated to key < {:?} > with a \
-                                 Timestamp equal to: {}",
-                                event.key_expr(),
-                                event.timestamp()
-                            );
-                            continue;
-                        }
-                    }
-                }
-                Action::WildcardPut(wildcard_ke) => {
-                    let wildcard_puts_guard = self.storage_service.wildcard_puts.read().await;
-
-                    if let Some(update) = wildcard_puts_guard.weight_at(wildcard_ke) {
-                        Some((update.payload().clone(), update.encoding().clone()))
-                    } else {
-                        tracing::error!(
-                            "Ignoring Wildcard Update < {wildcard_ke} >: found no associated \
-                             `Update`."
-                        );
-                        continue;
-                    }
-                }
+            let Some(value) = self.fetch_event_payload(event).await else {
+                continue;
             };
 
             let (payload, encoding) = match value {

--- a/plugins/zenoh-plugin-storage-manager/src/replication/log.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/log.rs
@@ -342,7 +342,11 @@ impl LogLatest {
     ) -> Self {
         // Default: 2 << 22 = 4_194_304 items, ~5MB per storage with replication enabled.
         let bloom_capacity = replica_config.bloom_filter_capacity.unwrap_or(2 << 22);
-        let bloom_fp_rate = replica_config.bloom_filter_fp_rate.unwrap_or(0.01);
+        // Default: 10 permille = 1% false positive rate.
+        let bloom_fp_rate = replica_config
+            .bloom_filter_fp_rate_permille
+            .map(|p| f64::from(p) / 1000.0)
+            .unwrap_or(0.01);
 
         Self {
             configuration: Configuration::new(storage_key_expr, prefix, replica_config),

--- a/plugins/zenoh-plugin-storage-manager/src/replication/tests/aligner_query.test.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/tests/aligner_query.test.rs
@@ -12,19 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-//! Tests for Piece 1 (protocol types) and Piece 2 (server-side batch retrieval handler).
-//!
-//! Piece 1 tests validate that the new protocol types exist and are serializable:
-//!   - `AlignmentQuery::EventsBatch(Vec<EventMetadata>)` variant
-//!   - `RetrievalItem` struct with EventMetadata, optional payload bytes, optional encoding bytes
-//!   - `AlignmentReply::RetrievalBatch(Vec<RetrievalItem>)` variant
-//!   - Bincode round-trip serialization for all new types
-//!
-//! Piece 2 tests validate the batching logic for the server-side handler, including:
-//!   - Chunking events into groups of `batch_size`
-//!   - Constructing `RetrievalItem` for different `Action` types
-//!   - Correct number of reply batches: ceil(N / batch_size)
-//!   - Payload inclusion for Put/WildcardPut, omission for Delete/WildcardDelete
+//! Tests for batch retrieval protocol types, serialization, and chunking logic.
 
 use std::str::FromStr;
 
@@ -34,7 +22,6 @@ use super::{chunk_events_for_batch_retrieval, AlignmentQuery};
 use crate::replication::core::aligner_reply::{AlignmentReply, RetrievalItem};
 use crate::replication::log::{Action, EventMetadata};
 
-/// Helper: create an `EventMetadata` with the given key and action.
 fn make_event_metadata(key: &str, action: Action) -> EventMetadata {
     let hlc = uhlc::HLC::default();
     EventMetadata {
@@ -49,438 +36,226 @@ fn make_event_metadata(key: &str, action: Action) -> EventMetadata {
 }
 
 // ===========================================================================
-// Piece 1: Protocol types — AlignmentQuery::EventsBatch, RetrievalItem,
-//          AlignmentReply::RetrievalBatch
+// AlignmentQuery::EventsBatch
 // ===========================================================================
 
-// ---------------------------------------------------------------------------
-// AlignmentQuery::EventsBatch(Vec<EventMetadata>) existence & serde
-// ---------------------------------------------------------------------------
-
 #[test]
-fn piece1_alignment_query_events_batch_variant_exists() {
-    let events = vec![make_event_metadata("piece1/a", Action::Put)];
-    let _query = AlignmentQuery::EventsBatch(events);
-}
-
-#[test]
-fn piece1_alignment_query_events_batch_bincode_roundtrip() {
+fn events_batch_bincode_roundtrip() {
     let events = vec![
-        make_event_metadata("piece1/x", Action::Put),
-        make_event_metadata("piece1/y", Action::Delete),
+        make_event_metadata("x", Action::Put),
+        make_event_metadata("y", Action::Delete),
     ];
     let query = AlignmentQuery::EventsBatch(events);
-
-    let serialized = bincode::serialize(&query).expect("serialize EventsBatch");
-    let deserialized: AlignmentQuery =
-        bincode::deserialize(&serialized).expect("deserialize EventsBatch");
-    assert_eq!(query, deserialized);
+    let bytes = bincode::serialize(&query).unwrap();
+    assert_eq!(query, bincode::deserialize::<AlignmentQuery>(&bytes).unwrap());
 }
 
 #[test]
-fn piece1_alignment_query_events_batch_empty_vec_roundtrip() {
+fn events_batch_empty_roundtrip() {
     let query = AlignmentQuery::EventsBatch(vec![]);
-
-    let serialized = bincode::serialize(&query).expect("serialize empty EventsBatch");
-    let deserialized: AlignmentQuery =
-        bincode::deserialize(&serialized).expect("deserialize empty EventsBatch");
-    assert_eq!(query, deserialized);
+    let bytes = bincode::serialize(&query).unwrap();
+    assert_eq!(query, bincode::deserialize::<AlignmentQuery>(&bytes).unwrap());
 }
 
 #[test]
-fn piece1_alignment_query_events_batch_preserves_event_data() {
-    let event = make_event_metadata("piece1/preserve", Action::Put);
-    let query = AlignmentQuery::EventsBatch(vec![event.clone()]);
-
-    match query {
-        AlignmentQuery::EventsBatch(ref events) => {
-            assert_eq!(events.len(), 1);
-            assert_eq!(events[0], event);
-        }
-        _ => panic!("Expected EventsBatch variant"),
-    }
+fn events_batch_is_distinct_from_events() {
+    let event = make_event_metadata("a", Action::Put);
+    assert_ne!(
+        AlignmentQuery::EventsBatch(vec![event.clone()]),
+        AlignmentQuery::Events(vec![event]),
+    );
 }
 
-// ---------------------------------------------------------------------------
-// RetrievalItem struct existence with correct field types
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// RetrievalItem
+// ===========================================================================
 
 #[test]
-fn piece1_retrieval_item_struct_with_payload_bytes() {
-    let metadata = make_event_metadata("piece1/item", Action::Put);
-    let payload: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
-    let encoding: Vec<u8> = vec![0x01, 0x02];
-
+fn retrieval_item_with_payload() {
+    let metadata = make_event_metadata("k", Action::Put);
     let item = RetrievalItem {
         event_metadata: metadata.clone(),
-        payload: Some(payload.clone()),
-        encoding: Some(encoding.clone()),
+        payload: Some(vec![0xDE, 0xAD]),
+        encoding: Some(vec![0x01]),
     };
-
     assert_eq!(item.event_metadata, metadata);
-    assert_eq!(item.payload, Some(payload));
-    assert_eq!(item.encoding, Some(encoding));
+    assert!(item.payload.is_some());
+    assert!(item.encoding.is_some());
 }
 
 #[test]
-fn piece1_retrieval_item_with_none_payload_and_encoding() {
-    let metadata = make_event_metadata("piece1/del", Action::Delete);
-
+fn retrieval_item_without_payload() {
     let item = RetrievalItem {
-        event_metadata: metadata.clone(),
+        event_metadata: make_event_metadata("k", Action::Delete),
         payload: None,
         encoding: None,
     };
-
-    assert_eq!(item.event_metadata, metadata);
     assert!(item.payload.is_none());
     assert!(item.encoding.is_none());
 }
 
 #[test]
-fn piece1_retrieval_item_bincode_roundtrip_with_payload() {
-    let metadata = make_event_metadata("piece1/serde", Action::Put);
+fn retrieval_item_bincode_roundtrip() {
     let item = RetrievalItem {
-        event_metadata: metadata,
-        payload: Some(vec![1, 2, 3, 4, 5]),
-        encoding: Some(vec![10, 20]),
+        event_metadata: make_event_metadata("k", Action::Put),
+        payload: Some(vec![1, 2, 3]),
+        encoding: Some(vec![10]),
     };
-
-    let serialized = bincode::serialize(&item).expect("serialize RetrievalItem");
-    let deserialized: RetrievalItem =
-        bincode::deserialize(&serialized).expect("deserialize RetrievalItem");
-    assert_eq!(item, deserialized);
+    let bytes = bincode::serialize(&item).unwrap();
+    assert_eq!(item, bincode::deserialize::<RetrievalItem>(&bytes).unwrap());
 }
 
 #[test]
-fn piece1_retrieval_item_bincode_roundtrip_without_payload() {
-    let metadata = make_event_metadata("piece1/serde-none", Action::Delete);
+fn retrieval_item_none_bincode_roundtrip() {
     let item = RetrievalItem {
-        event_metadata: metadata,
+        event_metadata: make_event_metadata("k", Action::Delete),
         payload: None,
         encoding: None,
     };
-
-    let serialized = bincode::serialize(&item).expect("serialize RetrievalItem (no payload)");
-    let deserialized: RetrievalItem =
-        bincode::deserialize(&serialized).expect("deserialize RetrievalItem (no payload)");
-    assert_eq!(item, deserialized);
+    let bytes = bincode::serialize(&item).unwrap();
+    assert_eq!(item, bincode::deserialize::<RetrievalItem>(&bytes).unwrap());
 }
 
-// ---------------------------------------------------------------------------
-// AlignmentReply::RetrievalBatch(Vec<RetrievalItem>) existence & serde
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// AlignmentReply::RetrievalBatch
+// ===========================================================================
 
 #[test]
-fn piece1_alignment_reply_retrieval_batch_variant_exists() {
-    let item = RetrievalItem {
-        event_metadata: make_event_metadata("piece1/reply", Action::Put),
-        payload: Some(vec![42u8]),
-        encoding: Some(vec![1u8]),
-    };
-    let _reply = AlignmentReply::RetrievalBatch(vec![item]);
-}
-
-#[test]
-fn piece1_alignment_reply_retrieval_batch_bincode_roundtrip() {
-    let items = vec![
+fn retrieval_batch_bincode_roundtrip() {
+    let reply = AlignmentReply::RetrievalBatch(vec![
         RetrievalItem {
-            event_metadata: make_event_metadata("piece1/r/a", Action::Put),
-            payload: Some(vec![1, 2, 3]),
-            encoding: Some(vec![99]),
+            event_metadata: make_event_metadata("a", Action::Put),
+            payload: Some(vec![1]),
+            encoding: Some(vec![2]),
         },
         RetrievalItem {
-            event_metadata: make_event_metadata("piece1/r/b", Action::Delete),
+            event_metadata: make_event_metadata("b", Action::Delete),
             payload: None,
             encoding: None,
         },
-    ];
-    let reply = AlignmentReply::RetrievalBatch(items);
-
-    let serialized = bincode::serialize(&reply).expect("serialize RetrievalBatch");
-    let deserialized: AlignmentReply =
-        bincode::deserialize(&serialized).expect("deserialize RetrievalBatch");
-    assert_eq!(reply, deserialized);
+    ]);
+    let bytes = bincode::serialize(&reply).unwrap();
+    assert_eq!(reply, bincode::deserialize::<AlignmentReply>(&bytes).unwrap());
 }
 
 #[test]
-fn piece1_alignment_reply_retrieval_batch_empty_vec_roundtrip() {
+fn retrieval_batch_empty_roundtrip() {
     let reply = AlignmentReply::RetrievalBatch(vec![]);
-
-    let serialized = bincode::serialize(&reply).expect("serialize empty RetrievalBatch");
-    let deserialized: AlignmentReply =
-        bincode::deserialize(&serialized).expect("deserialize empty RetrievalBatch");
-    assert_eq!(reply, deserialized);
+    let bytes = bincode::serialize(&reply).unwrap();
+    assert_eq!(reply, bincode::deserialize::<AlignmentReply>(&bytes).unwrap());
 }
 
 #[test]
-fn piece1_alignment_reply_retrieval_batch_preserves_items() {
-    let items = vec![
-        RetrievalItem {
-            event_metadata: make_event_metadata("piece1/p/0", Action::Put),
-            payload: Some(vec![10]),
-            encoding: Some(vec![20]),
-        },
-        RetrievalItem {
-            event_metadata: make_event_metadata("piece1/p/1", Action::Put),
-            payload: Some(vec![30]),
-            encoding: Some(vec![40]),
-        },
-        RetrievalItem {
-            event_metadata: make_event_metadata("piece1/p/2", Action::Delete),
-            payload: None,
-            encoding: None,
-        },
-    ];
+fn retrieval_batch_preserves_item_count() {
+    let items: Vec<RetrievalItem> = (0..5)
+        .map(|i| RetrievalItem {
+            event_metadata: make_event_metadata(&format!("k/{i}"), Action::Put),
+            payload: Some(vec![i as u8]),
+            encoding: Some(vec![0]),
+        })
+        .collect();
 
-    let reply = AlignmentReply::RetrievalBatch(items);
-    match reply {
-        AlignmentReply::RetrievalBatch(ref batch) => {
-            assert_eq!(batch.len(), 3);
-            assert!(batch[0].payload.is_some());
-            assert!(batch[2].payload.is_none());
-        }
-        _ => panic!("Expected RetrievalBatch variant"),
+    match AlignmentReply::RetrievalBatch(items) {
+        AlignmentReply::RetrievalBatch(batch) => assert_eq!(batch.len(), 5),
+        _ => panic!("Expected RetrievalBatch"),
     }
 }
 
 // ===========================================================================
-// Piece 2: Server-side batch retrieval handler
+// RetrievalItem per Action type
 // ===========================================================================
 
-// ---------------------------------------------------------------------------
-// Tests for AlignmentQuery::EventsBatch variant
-// ---------------------------------------------------------------------------
-
 #[test]
-fn piece2_events_batch_variant_exists() {
-    let events = vec![make_event_metadata("a/b", Action::Put)];
-
-    let query = AlignmentQuery::EventsBatch(events);
-
-    let serialized = bincode::serialize(&query).expect("serialize EventsBatch");
-    let deserialized: AlignmentQuery =
-        bincode::deserialize(&serialized).expect("deserialize EventsBatch");
-    assert_eq!(query, deserialized);
-}
-
-// ---------------------------------------------------------------------------
-// Tests for AlignmentReply::RetrievalBatch variant
-// ---------------------------------------------------------------------------
-
-#[test]
-fn piece2_retrieval_batch_variant_exists() {
+fn retrieval_item_wildcard_put_has_payload() {
+    let ke = OwnedKeyExpr::from_str("sensor/**").unwrap();
     let item = RetrievalItem {
-        event_metadata: make_event_metadata("a/b", Action::Put),
-        payload: Some(vec![1u8, 2, 3]),
-        encoding: Some(vec![0u8]),
+        event_metadata: make_event_metadata("sensor/**", Action::WildcardPut(ke)),
+        payload: Some(vec![99]),
+        encoding: Some(vec![0]),
     };
-
-    let reply = AlignmentReply::RetrievalBatch(vec![item]);
-
-    let serialized = bincode::serialize(&reply).expect("serialize RetrievalBatch");
-    let deserialized: AlignmentReply =
-        bincode::deserialize(&serialized).expect("deserialize RetrievalBatch");
-    assert_eq!(reply, deserialized);
-}
-
-// ---------------------------------------------------------------------------
-// Tests for RetrievalItem construction per Action type
-// ---------------------------------------------------------------------------
-
-#[test]
-fn piece2_retrieval_item_put_has_payload() {
-    let metadata = make_event_metadata("sensor/temp", Action::Put);
-    let payload_bytes = vec![42u8; 64];
-
-    let item = RetrievalItem {
-        event_metadata: metadata.clone(),
-        payload: Some(payload_bytes.clone()),
-        encoding: Some(vec![0u8]),
-    };
-
-    assert_eq!(item.event_metadata, metadata);
-    assert!(item.payload.is_some(), "Put events must include payload");
-    assert!(item.encoding.is_some(), "Put events must include encoding");
+    assert!(item.payload.is_some());
 }
 
 #[test]
-fn piece2_retrieval_item_delete_has_no_payload() {
-    let metadata = make_event_metadata("sensor/temp", Action::Delete);
-
+fn retrieval_item_wildcard_delete_has_no_payload() {
+    let ke = OwnedKeyExpr::from_str("sensor/**").unwrap();
     let item = RetrievalItem {
-        event_metadata: metadata.clone(),
+        event_metadata: make_event_metadata("sensor/**", Action::WildcardDelete(ke)),
         payload: None,
         encoding: None,
     };
-
-    assert_eq!(item.event_metadata, metadata);
-    assert!(
-        item.payload.is_none(),
-        "Delete events must NOT include payload"
-    );
-    assert!(
-        item.encoding.is_none(),
-        "Delete events must NOT include encoding"
-    );
+    assert!(item.payload.is_none());
 }
 
-#[test]
-fn piece2_retrieval_item_wildcard_put_has_payload() {
-    let wildcard_ke = OwnedKeyExpr::from_str("sensor/**").expect("valid wildcard key");
-    let metadata = make_event_metadata("sensor/**", Action::WildcardPut(wildcard_ke));
-    let payload_bytes = vec![99u8; 32];
-
-    let item = RetrievalItem {
-        event_metadata: metadata.clone(),
-        payload: Some(payload_bytes),
-        encoding: Some(vec![0u8]),
-    };
-
-    assert!(
-        item.payload.is_some(),
-        "WildcardPut events must include payload"
-    );
-    assert!(
-        item.encoding.is_some(),
-        "WildcardPut events must include encoding"
-    );
-}
+// ===========================================================================
+// chunk_events_for_batch_retrieval
+// ===========================================================================
 
 #[test]
-fn piece2_retrieval_item_wildcard_delete_has_no_payload() {
-    let wildcard_ke = OwnedKeyExpr::from_str("sensor/**").expect("valid wildcard key");
-    let metadata = make_event_metadata("sensor/**", Action::WildcardDelete(wildcard_ke));
-
-    let item = RetrievalItem {
-        event_metadata: metadata.clone(),
-        payload: None,
-        encoding: None,
-    };
-
-    assert!(
-        item.payload.is_none(),
-        "WildcardDelete events must NOT include payload"
-    );
-    assert!(
-        item.encoding.is_none(),
-        "WildcardDelete events must NOT include encoding"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Tests for batch chunking logic
-// ---------------------------------------------------------------------------
-
-#[test]
-fn piece2_chunk_exact_division() {
+fn chunk_exact_division() {
     let events: Vec<EventMetadata> = (0..10)
-        .map(|i| make_event_metadata(&format!("key/{i}"), Action::Put))
+        .map(|i| make_event_metadata(&format!("k/{i}"), Action::Put))
         .collect();
-
     let chunks = chunk_events_for_batch_retrieval(&events, 5);
-
-    assert_eq!(chunks.len(), 2, "10 events / batch_size 5 = 2 chunks");
+    assert_eq!(chunks.len(), 2);
     assert_eq!(chunks[0].len(), 5);
     assert_eq!(chunks[1].len(), 5);
 }
 
 #[test]
-fn piece2_chunk_remainder() {
+fn chunk_with_remainder() {
     let events: Vec<EventMetadata> = (0..7)
-        .map(|i| make_event_metadata(&format!("key/{i}"), Action::Put))
+        .map(|i| make_event_metadata(&format!("k/{i}"), Action::Put))
         .collect();
-
     let chunks = chunk_events_for_batch_retrieval(&events, 3);
-
-    assert_eq!(
-        chunks.len(),
-        3,
-        "7 events / batch_size 3 = 3 chunks (ceil)"
-    );
-    assert_eq!(chunks[0].len(), 3);
-    assert_eq!(chunks[1].len(), 3);
-    assert_eq!(chunks[2].len(), 1, "Last chunk gets the remainder");
+    assert_eq!(chunks.len(), 3);
+    assert_eq!(chunks[2].len(), 1);
 }
 
 #[test]
-fn piece2_chunk_single_batch_when_n_leq_batch_size() {
+fn chunk_single_when_under_batch_size() {
     let events: Vec<EventMetadata> = (0..3)
-        .map(|i| make_event_metadata(&format!("key/{i}"), Action::Delete))
+        .map(|i| make_event_metadata(&format!("k/{i}"), Action::Put))
         .collect();
-
     let chunks = chunk_events_for_batch_retrieval(&events, 10);
-
-    assert_eq!(
-        chunks.len(),
-        1,
-        "When N <= batch_size, there should be exactly 1 chunk"
-    );
-    assert_eq!(chunks[0].len(), 3);
+    assert_eq!(chunks.len(), 1);
 }
 
 #[test]
-fn piece2_chunk_empty_events() {
-    let events: Vec<EventMetadata> = vec![];
-
-    let chunks = chunk_events_for_batch_retrieval(&events, 5);
-
-    assert_eq!(chunks.len(), 0, "Empty event list should produce 0 chunks");
+fn chunk_empty_events() {
+    let chunks = chunk_events_for_batch_retrieval(&[], 5);
+    assert_eq!(chunks.len(), 0);
 }
 
 #[test]
-fn piece2_chunk_batch_size_one() {
+fn chunk_batch_size_one() {
     let events: Vec<EventMetadata> = (0..4)
-        .map(|i| make_event_metadata(&format!("key/{i}"), Action::Put))
+        .map(|i| make_event_metadata(&format!("k/{i}"), Action::Put))
         .collect();
-
-    let chunks: Vec<&[EventMetadata]> = chunk_events_for_batch_retrieval(&events, 1);
-
-    assert_eq!(
-        chunks.len(),
-        4,
-        "batch_size=1 should produce one chunk per event"
-    );
-    for chunk in &chunks {
-        assert_eq!(chunk.len(), 1);
-    }
+    let chunks = chunk_events_for_batch_retrieval(&events, 1);
+    assert_eq!(chunks.len(), 4);
 }
 
 #[test]
-fn piece2_chunk_preserves_event_order() {
+fn chunk_preserves_order() {
     let events: Vec<EventMetadata> = (0..6)
         .map(|i| make_event_metadata(&format!("ordered/{i}"), Action::Put))
         .collect();
-
     let chunks = chunk_events_for_batch_retrieval(&events, 2);
-
-    assert_eq!(chunks.len(), 3);
     assert_eq!(
         chunks[0][0].stripped_key,
         Some(OwnedKeyExpr::from_str("ordered/0").unwrap())
     );
     assert_eq!(
-        chunks[0][1].stripped_key,
-        Some(OwnedKeyExpr::from_str("ordered/1").unwrap())
-    );
-    assert_eq!(
         chunks[1][0].stripped_key,
         Some(OwnedKeyExpr::from_str("ordered/2").unwrap())
     );
-    assert_eq!(
-        chunks[1][1].stripped_key,
-        Some(OwnedKeyExpr::from_str("ordered/3").unwrap())
-    );
 }
 
-// ---------------------------------------------------------------------------
-// Tests for reply count = ceil(N / batch_size)
-// ---------------------------------------------------------------------------
-
 #[test]
-fn piece2_reply_count_matches_chunk_count() {
-    for (n_events, batch_size, expected_replies) in [
-        (0usize, 5usize, 0usize),
+fn chunk_count_matches_ceil_division() {
+    for (n, bs, expected) in [
+        (0, 5, 0),
         (1, 5, 1),
         (5, 5, 1),
         (6, 5, 2),
@@ -488,70 +263,28 @@ fn piece2_reply_count_matches_chunk_count() {
         (11, 5, 3),
         (100, 10, 10),
         (101, 10, 11),
-        (1, 1, 1),
-        (7, 3, 3),
     ] {
-        let events: Vec<EventMetadata> = (0..n_events)
-            .map(|i| make_event_metadata(&format!("key/{i}"), Action::Put))
+        let events: Vec<EventMetadata> = (0..n)
+            .map(|i| make_event_metadata(&format!("k/{i}"), Action::Put))
             .collect();
-
-        let chunks = chunk_events_for_batch_retrieval(&events, batch_size);
-
         assert_eq!(
-            chunks.len(),
-            expected_replies,
-            "For {n_events} events with batch_size={batch_size}, expected {expected_replies} \
-             replies but got {}",
-            chunks.len()
+            chunk_events_for_batch_retrieval(&events, bs).len(),
+            expected,
+            "n={n}, bs={bs}"
         );
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tests for mixed Action types in a single batch
-// ---------------------------------------------------------------------------
-
 #[test]
-fn piece2_chunk_mixed_action_types() {
-    let wildcard_ke = OwnedKeyExpr::from_str("test/**").expect("valid wildcard key");
-
+fn chunk_mixed_action_types() {
+    let ke = OwnedKeyExpr::from_str("test/**").unwrap();
     let events = vec![
-        make_event_metadata("a/put", Action::Put),
-        make_event_metadata("b/delete", Action::Delete),
-        make_event_metadata("test/**", Action::WildcardPut(wildcard_ke.clone())),
-        make_event_metadata("test/**", Action::WildcardDelete(wildcard_ke)),
+        make_event_metadata("a", Action::Put),
+        make_event_metadata("b", Action::Delete),
+        make_event_metadata("test/**", Action::WildcardPut(ke.clone())),
+        make_event_metadata("test/**", Action::WildcardDelete(ke)),
     ];
-
     let chunks = chunk_events_for_batch_retrieval(&events, 4);
     assert_eq!(chunks.len(), 1);
     assert_eq!(chunks[0].len(), 4);
-
-    assert_eq!(chunks[0][0].action, Action::Put);
-    assert_eq!(chunks[0][1].action, Action::Delete);
-    assert!(matches!(chunks[0][2].action, Action::WildcardPut(_)));
-    assert!(matches!(chunks[0][3].action, Action::WildcardDelete(_)));
-}
-
-// ---------------------------------------------------------------------------
-// Test: RetrievalBatch contains the right number of RetrievalItems
-// ---------------------------------------------------------------------------
-
-#[test]
-fn piece2_retrieval_batch_item_count_matches_chunk() {
-    let items: Vec<RetrievalItem> = (0..5)
-        .map(|i| RetrievalItem {
-            event_metadata: make_event_metadata(&format!("item/{i}"), Action::Put),
-            payload: Some(vec![i as u8; 8]),
-            encoding: Some(vec![0u8]),
-        })
-        .collect();
-
-    let reply = AlignmentReply::RetrievalBatch(items);
-
-    match reply {
-        AlignmentReply::RetrievalBatch(ref batch_items) => {
-            assert_eq!(batch_items.len(), 5);
-        }
-        _ => panic!("Expected RetrievalBatch variant"),
-    }
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replication/tests/aligner_reply.test.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/tests/aligner_reply.test.rs
@@ -12,14 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-//! Tests for Piece 3: Client-side batch processing and fallback.
-//!
-//! These tests verify:
-//! - `AlignmentQuery::EventsBatch` variant exists and can be constructed
-//! - `AlignmentReply::RetrievalBatch` variant exists and can be matched
-//! - `RetrievalItem` struct exists with the expected fields (event_metadata + optional payload bytes)
-//! - EventsMetadata handler constructs EventsBatch (not Events) for batch retrieval
-//! - Backward compatibility fallback: if EventsBatch gets no replies, fall back to Events
+//! Tests for client-side batch processing: RetrievalBatch handling, payload
+//! reconstruction, and backward compatibility fallback from EventsBatch to Events.
 
 use std::str::FromStr;
 
@@ -29,229 +23,78 @@ use super::{AlignmentReply, RetrievalItem};
 use crate::replication::core::aligner_query::AlignmentQuery;
 use crate::replication::log::{Action, EventMetadata};
 
-// ---------------------------------------------------------------------------
-// AC1: AlignmentQuery::EventsBatch variant exists
-// ---------------------------------------------------------------------------
-
-#[test]
-fn piece3_events_batch_query_variant_exists() {
+fn make_event(key: &str) -> EventMetadata {
     let hlc = uhlc::HLC::default();
-    let event = EventMetadata {
-        stripped_key: Some(OwnedKeyExpr::from_str("test/a").unwrap()),
+    EventMetadata {
+        stripped_key: Some(OwnedKeyExpr::from_str(key).unwrap()),
         timestamp: hlc.new_timestamp(),
         timestamp_last_non_wildcard_update: None,
         action: Action::Put,
-    };
-
-    let query = AlignmentQuery::EventsBatch(vec![event]);
-
-    let serialized = bincode::serialize(&query).expect("serialize EventsBatch");
-    let deserialized: AlignmentQuery =
-        bincode::deserialize(&serialized).expect("deserialize EventsBatch");
-    assert_eq!(query, deserialized);
-}
-
-#[test]
-fn piece3_events_batch_is_distinct_from_events() {
-    let hlc = uhlc::HLC::default();
-    let event = EventMetadata {
-        stripped_key: Some(OwnedKeyExpr::from_str("test/b").unwrap()),
-        timestamp: hlc.new_timestamp(),
-        timestamp_last_non_wildcard_update: None,
-        action: Action::Put,
-    };
-
-    let batch_query = AlignmentQuery::EventsBatch(vec![event.clone()]);
-    let single_query = AlignmentQuery::Events(vec![event]);
-
-    assert_ne!(batch_query, single_query);
+    }
 }
 
 // ---------------------------------------------------------------------------
-// AC2: AlignmentReply::RetrievalBatch variant exists with RetrievalItem
+// RetrievalBatch match arm
 // ---------------------------------------------------------------------------
 
 #[test]
-fn piece3_retrieval_item_struct_exists() {
-    let hlc = uhlc::HLC::default();
-    let event = EventMetadata {
-        stripped_key: Some(OwnedKeyExpr::from_str("test/c").unwrap()),
-        timestamp: hlc.new_timestamp(),
-        timestamp_last_non_wildcard_update: None,
-        action: Action::Put,
-    };
-
+fn retrieval_batch_can_be_matched() {
     let item = RetrievalItem {
-        event_metadata: event.clone(),
-        payload: Some(vec![1, 2, 3, 4]),
-        encoding: None,
-    };
-
-    assert_eq!(item.event_metadata, event);
-    assert_eq!(item.payload, Some(vec![1, 2, 3, 4]));
-}
-
-#[test]
-fn piece3_retrieval_batch_reply_variant_exists() {
-    let hlc = uhlc::HLC::default();
-
-    let items: Vec<RetrievalItem> = (0..3)
-        .map(|i| {
-            let event = EventMetadata {
-                stripped_key: Some(OwnedKeyExpr::from_str(&format!("test/{i}")).unwrap()),
-                timestamp: hlc.new_timestamp(),
-                timestamp_last_non_wildcard_update: None,
-                action: Action::Put,
-            };
-            RetrievalItem {
-                event_metadata: event,
-                payload: Some(vec![i as u8; 10]),
-                encoding: None,
-            }
-        })
-        .collect();
-
-    let reply = AlignmentReply::RetrievalBatch(items);
-
-    let serialized = bincode::serialize(&reply).expect("serialize RetrievalBatch");
-    let deserialized: AlignmentReply =
-        bincode::deserialize(&serialized).expect("deserialize RetrievalBatch");
-    assert_eq!(reply, deserialized);
-}
-
-#[test]
-fn piece3_retrieval_batch_can_be_matched() {
-    let hlc = uhlc::HLC::default();
-    let event = EventMetadata {
-        stripped_key: Some(OwnedKeyExpr::from_str("test/match").unwrap()),
-        timestamp: hlc.new_timestamp(),
-        timestamp_last_non_wildcard_update: None,
-        action: Action::Put,
-    };
-
-    let item = RetrievalItem {
-        event_metadata: event,
+        event_metadata: make_event("test/match"),
         payload: Some(vec![42]),
         encoding: None,
     };
-
-    let reply = AlignmentReply::RetrievalBatch(vec![item]);
-
-    match reply {
+    match AlignmentReply::RetrievalBatch(vec![item]) {
         AlignmentReply::RetrievalBatch(items) => {
             assert_eq!(items.len(), 1);
             assert_eq!(items[0].payload, Some(vec![42]));
         }
-        _ => panic!("Expected RetrievalBatch variant"),
+        _ => panic!("Expected RetrievalBatch"),
     }
 }
 
 // ---------------------------------------------------------------------------
-// AC2 (continued): RetrievalBatch items carry enough info for process_event_retrieval
+// Payload reconstruction: RetrievalItem bytes → ZBytes
 // ---------------------------------------------------------------------------
 
 #[test]
-fn piece3_retrieval_item_carries_payload_for_sample_reconstruction() {
-    let hlc = uhlc::HLC::default();
+fn retrieval_item_payload_reconstructs_to_zbytes() {
     let payload_bytes: Vec<u8> = b"hello zenoh batch".to_vec();
-
-    let event = EventMetadata {
-        stripped_key: Some(OwnedKeyExpr::from_str("test/payload").unwrap()),
-        timestamp: hlc.new_timestamp(),
-        timestamp_last_non_wildcard_update: None,
-        action: Action::Put,
-    };
-
     let item = RetrievalItem {
-        event_metadata: event.clone(),
+        event_metadata: make_event("test/payload"),
         payload: Some(payload_bytes.clone()),
         encoding: None,
     };
-
-    // The payload bytes should be usable to create ZBytes
-    let zbytes = zenoh::bytes::ZBytes::from(item.payload.clone().unwrap());
-    let round_tripped: Vec<u8> = zbytes.to_bytes().to_vec();
-    assert_eq!(round_tripped, payload_bytes);
-
-    assert_eq!(item.event_metadata.stripped_key, event.stripped_key);
-    assert_eq!(item.event_metadata.timestamp, event.timestamp);
-    assert_eq!(item.event_metadata.action, Action::Put);
+    let zbytes = zenoh::bytes::ZBytes::from(item.payload.unwrap());
+    assert_eq!(zbytes.to_bytes().to_vec(), payload_bytes);
 }
 
 // ---------------------------------------------------------------------------
-// AC3: EventsMetadata handler should construct EventsBatch instead of Events
+// Backward compatibility: EventsBatch and Events carry same events
 // ---------------------------------------------------------------------------
 
 #[test]
-fn piece3_events_metadata_handler_uses_events_batch_query() {
-    let hlc = uhlc::HLC::default();
+fn events_batch_and_events_carry_same_payload() {
+    let events: Vec<EventMetadata> = (0..3).map(|i| make_event(&format!("fb/{i}"))).collect();
 
-    let diff_events: Vec<EventMetadata> = (0..5)
-        .map(|i| EventMetadata {
-            stripped_key: Some(OwnedKeyExpr::from_str(&format!("test/diff/{i}")).unwrap()),
-            timestamp: hlc.new_timestamp(),
-            timestamp_last_non_wildcard_update: None,
-            action: Action::Put,
-        })
-        .collect();
+    let batch_bytes = bincode::serialize(&AlignmentQuery::EventsBatch(events.clone())).unwrap();
+    let legacy_bytes = bincode::serialize(&AlignmentQuery::Events(events)).unwrap();
 
-    let query = AlignmentQuery::EventsBatch(diff_events.clone());
-
-    match query {
-        AlignmentQuery::EventsBatch(events) => {
-            assert_eq!(events.len(), 5);
-            assert_eq!(events[0].stripped_key, diff_events[0].stripped_key);
-        }
-        _ => panic!("Expected EventsBatch, got a different variant"),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// AC4: Backward compatibility — fallback from EventsBatch to Events
-// ---------------------------------------------------------------------------
-
-#[test]
-fn piece3_fallback_events_batch_to_events_same_payload() {
-    let hlc = uhlc::HLC::default();
-
-    let events: Vec<EventMetadata> = (0..3)
-        .map(|i| EventMetadata {
-            stripped_key: Some(OwnedKeyExpr::from_str(&format!("test/fallback/{i}")).unwrap()),
-            timestamp: hlc.new_timestamp(),
-            timestamp_last_non_wildcard_update: None,
-            action: Action::Put,
-        })
-        .collect();
-
-    let batch_query = AlignmentQuery::EventsBatch(events.clone());
-    let legacy_query = AlignmentQuery::Events(events.clone());
-
-    let batch_bytes = bincode::serialize(&batch_query).expect("serialize EventsBatch");
-    let legacy_bytes = bincode::serialize(&legacy_query).expect("serialize Events");
-
-    // Different discriminants
+    // Different discriminants, same inner data.
     assert_ne!(batch_bytes, legacy_bytes);
-
-    // Same inner events
     match (
         bincode::deserialize::<AlignmentQuery>(&batch_bytes).unwrap(),
         bincode::deserialize::<AlignmentQuery>(&legacy_bytes).unwrap(),
     ) {
-        (AlignmentQuery::EventsBatch(batch_evts), AlignmentQuery::Events(legacy_evts)) => {
-            assert_eq!(batch_evts, legacy_evts);
-        }
-        _ => panic!("Unexpected deserialization result"),
+        (AlignmentQuery::EventsBatch(a), AlignmentQuery::Events(b)) => assert_eq!(a, b),
+        _ => panic!("Unexpected deserialization"),
     }
 }
 
 #[test]
-fn piece3_empty_retrieval_batch_signals_fallback() {
-    let reply = AlignmentReply::RetrievalBatch(Vec::<RetrievalItem>::new());
-
-    match reply {
-        AlignmentReply::RetrievalBatch(items) if items.is_empty() => {
-            // Empty batch signals fallback condition
-        }
+fn empty_retrieval_batch_is_detectable() {
+    match AlignmentReply::RetrievalBatch(vec![]) {
+        AlignmentReply::RetrievalBatch(items) if items.is_empty() => {}
         _ => panic!("Expected empty RetrievalBatch"),
     }
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replication/tests/configuration.test.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/tests/configuration.test.rs
@@ -31,7 +31,7 @@ fn test_lower_bounds() {
             propagation_delay: Duration::from_millis(250),
             batch_size: 100,
             bloom_filter_capacity: None,
-            bloom_filter_fp_rate: None,
+            bloom_filter_fp_rate_permille: None,
         },
     );
 
@@ -55,7 +55,7 @@ fn test_difference() {
         propagation_delay: Duration::from_millis(250),
         batch_size: 100,
         bloom_filter_capacity: None,
-        bloom_filter_fp_rate: None,
+        bloom_filter_fp_rate_permille: None,
     };
 
     let configuration_a = Configuration::new(
@@ -94,7 +94,7 @@ fn test_get_classification() {
             propagation_delay: Duration::from_millis(250),
             batch_size: 100,
             bloom_filter_capacity: None,
-            bloom_filter_fp_rate: None,
+            bloom_filter_fp_rate_permille: None,
         },
     );
 
@@ -172,7 +172,7 @@ fn piece1_batch_size_not_included_in_configuration_fingerprint() {
         propagation_delay: Duration::from_millis(250),
         batch_size: 100,
         bloom_filter_capacity: None,
-        bloom_filter_fp_rate: None,
+        bloom_filter_fp_rate_permille: None,
     };
 
     let config_b = ReplicaConfig {
@@ -183,7 +183,7 @@ fn piece1_batch_size_not_included_in_configuration_fingerprint() {
         propagation_delay: Duration::from_millis(250),
         batch_size: 500,
         bloom_filter_capacity: None,
-        bloom_filter_fp_rate: None,
+        bloom_filter_fp_rate_permille: None,
     };
 
     let configuration_a = Configuration::new(key_expr.clone(), None, config_a);
@@ -202,13 +202,13 @@ fn bloom_filter_fields_not_included_in_configuration_fingerprint() {
 
     let config_a = ReplicaConfig {
         bloom_filter_capacity: None,
-        bloom_filter_fp_rate: None,
+        bloom_filter_fp_rate_permille: None,
         ..ReplicaConfig::default()
     };
 
     let config_b = ReplicaConfig {
         bloom_filter_capacity: Some(1_000_000),
-        bloom_filter_fp_rate: Some(0.001),
+        bloom_filter_fp_rate_permille: Some(1),
         ..ReplicaConfig::default()
     };
 

--- a/plugins/zenoh-plugin-storage-manager/src/replication/tests/log.test.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/tests/log.test.rs
@@ -56,7 +56,7 @@ fn test_insert() {
             propagation_delay: Duration::from_millis(250),
             batch_size: 100,
             bloom_filter_capacity: None,
-            bloom_filter_fp_rate: None,
+            bloom_filter_fp_rate_permille: None,
         },
     );
 
@@ -123,7 +123,7 @@ fn test_digest() {
             propagation_delay: Duration::from_millis(250),
             batch_size: 100,
             bloom_filter_capacity: None,
-            bloom_filter_fp_rate: None,
+            bloom_filter_fp_rate_permille: None,
         },
     );
 


### PR DESCRIPTION
## Summary
Mirror of PR #49 (targeting zenoh/repl-vol) applied to the full working branch.

- Extract `fetch_event_payload()` to deduplicate batch/single retrieval paths
- Change `bloom_filter_fp_rate: Option<f64>` to `bloom_filter_fp_rate_permille: Option<u16>` (preserves `Eq`)
- Rename tests to behavioral names, deduplicate overlapping tests

All 48 tests pass, clippy clean. Net -476 lines.