### PR TITLE
refactor: discriminant parity test + log reply errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6092,6 +6092,7 @@ dependencies = [
  "zenoh-plugin-storage-manager",
  "zenoh-plugin-trait",
  "zenoh-util",
+ "zenoh_backend_traits",
 ]
 
 [[package]]

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
@@ -566,9 +566,16 @@ impl StorageService {
 
         if is_ack_put || is_ack_delete {
             if is_ack_put && q.payload().is_none() {
-                let _ = q
+                if let Err(e) = q
                     .reply_err(ZBytes::from("_ack_put requires a payload"))
-                    .await;
+                    .await
+                {
+                    tracing::warn!(
+                        "Storage '{}' failed to send error reply for missing payload: {}",
+                        self.name,
+                        e
+                    );
+                }
                 return;
             }
 
@@ -576,7 +583,13 @@ impl StorageService {
                 Ok(k) => k,
                 Err(e) => {
                     tracing::error!("{}", e);
-                    let _ = q.reply_err(ZBytes::from(format!("{e}"))).await;
+                    if let Err(reply_err) = q.reply_err(ZBytes::from(format!("{e}"))).await {
+                        tracing::warn!(
+                            "Storage '{}' failed to send error reply for strip_prefix: {}",
+                            self.name,
+                            reply_err
+                        );
+                    }
                     return;
                 }
             };
@@ -629,7 +642,14 @@ impl StorageService {
                         op,
                         e
                     );
-                    let _ = q.reply_err(ZBytes::from(format!("{e}"))).await;
+                    if let Err(reply_err) = q.reply_err(ZBytes::from(format!("{e}"))).await {
+                        tracing::warn!(
+                            "Storage '{}' failed to send error reply for {}: {}",
+                            self.name,
+                            op,
+                            reply_err
+                        );
+                    }
                 }
             }
 

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -53,6 +53,7 @@ zenoh-util = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+zenoh_backend_traits = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-plugin-storage-manager = { path = "../plugins/zenoh-plugin-storage-manager" }
 zenoh-plugin-trait = { workspace = true }

--- a/zenoh-ext/tests/ack_put.rs
+++ b/zenoh-ext/tests/ack_put.rs
@@ -177,5 +177,17 @@ async fn ack_put_integration() {
         StorageInsertionResult::Replaced,
         "ack_put over existing value should return Replaced"
     );
+}
 
+/// Ensures the duplicated `StorageInsertionResult` in `zenoh-ext` stays in sync
+/// with the source-of-truth in `zenoh-backend-traits`.
+#[test]
+fn discriminant_parity() {
+    use zenoh_backend_traits::StorageInsertionResult as BackendResult;
+    use zenoh_ext::StorageInsertionResult as ExtResult;
+
+    assert_eq!(BackendResult::Outdated as u8, ExtResult::Outdated as u8);
+    assert_eq!(BackendResult::Inserted as u8, ExtResult::Inserted as u8);
+    assert_eq!(BackendResult::Replaced as u8, ExtResult::Replaced as u8);
+    assert_eq!(BackendResult::Deleted as u8, ExtResult::Deleted as u8);
 }


### PR DESCRIPTION
## Summary
- Add `discriminant_parity` test ensuring the duplicated `StorageInsertionResult` enum in `zenoh-ext` stays in sync with `zenoh-backend-traits`
- Replace 3 `let _ = q.reply_err(...)` calls in the ack handler with `if let Err(e)` + `tracing::warn!` so reply failures are no longer silently swallowed
- Add `zenoh_backend_traits` as a dev-dependency of `zenoh-ext`

## Test plan
- [x] `cargo test -p zenoh-ext --test ack_put` — both `discriminant_parity` and `ack_put_integration` pass
- [x] `cargo test -p zenoh-plugin-storage-manager --test ack_operations` — passes
- [x] `cargo clippy -p zenoh-ext --test ack_put -p zenoh-plugin-storage-manager -- -D warnings` — clean