### PR TITLE
refactor: safety comments, unstable docs, cleanup (#81)

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -878,6 +878,8 @@ validated_struct::validator! {
 
         /// Maximum number of transport connections allowed.
         /// When set, new connections beyond this limit will be rejected.
+        ///
+        /// **Unstable** — this field may change or be removed before stabilization.
         pub max_connections: Option<usize>,
 
         /// Configuration of the downsampling.

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -345,6 +345,7 @@ pub(crate) fn on_admin_query(
         if let Some(max) = runtime.max_connections() {
             conn_json["max_connections"] = serde_json::json!(max);
         }
+        // SAFETY: "connections" is a valid key expression (no wildcards or special chars).
         let ke_connections = unsafe { keyexpr::from_str_unchecked("connections") };
         reply(match_prefix, reply_prefix, ke_connections, &query, &conn_json);
     }

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -563,12 +563,12 @@ impl RuntimeBuilder {
             shm_clients,
         } = self;
 
-        // max_connections is enforced via the transport layer's max_sessions mechanism,
-        // which rejects connections during the protocol handshake (before OPEN ACK).
-        // This ensures the remote peer's zenoh::open() returns Err rather than
-        // succeeding and then being closed asynchronously.
+        // Map max_connections to the transport layer's max_sessions, which rejects
+        // connections during the protocol handshake (before OPEN ACK). We inject into
+        // the config because TransportManager::builder().from_config() reads max_sessions
+        // from config — there is no direct setter on the builder.
         if let Some(max) = *config.max_connections() {
-            tracing::info!("max_connections={max} configured, setting transport/unicast/max_sessions");
+            tracing::info!("max_connections={max}, mapping to transport/unicast/max_sessions");
             config
                 .insert_json5("transport/unicast/max_sessions", &max.to_string())
                 .map_err(|e| zerror!("Failed to set max_sessions from max_connections: {}", e))?;

--- a/zenoh/tests/namespace.rs
+++ b/zenoh/tests/namespace.rs
@@ -698,7 +698,6 @@ async fn get_router_config_with_max_connections(
         .unwrap();
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     // Set the per-namespace connection limit.
-    // This field does not exist yet — Red Phase: expected compile/runtime error.
     config
         .insert_json5("max_connections", &max_connections.to_string())
         .unwrap();


### PR DESCRIPTION
## Summary
- Add `// SAFETY:` comment on `keyexpr::from_str_unchecked("connections")` in admin.rs
- Mark `max_connections` config field as unstable in doc comment
- Remove TDD leftover comment from namespace test
- Improve comment on config mutation in RuntimeBuilder::build()

## Testing
- Clippy clean, no behavior change — comments and docs only

Closes #81