### PR TITLE
docs: ACL decision chain, hot-path analysis, connection count (#82)

### DIFF
--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -17,6 +17,17 @@
 //! This module is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
+//!
+//! # Namespace-aware ACL authorization
+//!
+//! Decision priority (highest to lowest):
+//! 1. **Explicit deny** — per-subject deny rule matches the key expression
+//! 2. **Explicit allow** — per-subject allow rule matches the key expression
+//! 3. **Namespace deny** — key expression is outside the configured namespace prefix
+//! 4. **Default permission** — the configured default (Allow or Deny)
+//!
+//! When no namespace is configured, step 3 is skipped — the default permission applies directly.
+//! When no ACL rules are configured (empty policy map), only steps 3-4 apply.
 use std::collections::{HashMap, HashSet};
 
 use ahash::RandomState;
@@ -622,6 +633,16 @@ impl PolicyEnforcer {
     }
 
     /// Check each msg against the ACL ruleset for allow/deny.
+    ///
+    /// ## Performance
+    ///
+    /// Called on every message. The namespace check (`namespace.is_none()` at the
+    /// fast-path branch and `is_under_namespace()` in `namespace_aware_default()`)
+    /// adds at most one `Option::is_none()` check and one `keyexpr::starts_with()`
+    /// comparison to the hot path. Both are O(1) operations on stack-local data —
+    /// no allocation, no lock, no syscall. When no namespace is configured, the
+    /// `is_none()` fast-path returns immediately without entering
+    /// `namespace_aware_default()`.
     pub fn policy_decision_point(
         &self,
         subject: usize,

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -798,6 +798,14 @@ impl Runtime {
         self.state.max_connections
     }
 
+    /// Returns the number of active non-local connections (faces).
+    ///
+    /// **Complexity**: O(n) — acquires a read lock on `router.tables.tables` and
+    /// iterates all faces. This is acceptable because the method is only called
+    /// from admin space queries, which are infrequent. Introducing an `AtomicUsize`
+    /// counter would require instrumenting face add/remove across all four HAT
+    /// implementations (router, client, p2p_peer, linkstate_peer), adding coupling
+    /// for negligible gain on an infrequent code path.
     pub(crate) fn active_connections_count(&self) -> usize {
         let tables = zread!(self.state.router.tables.tables);
         tables.faces.values().filter(|f| !f.is_local).count()


### PR DESCRIPTION
## Summary
- Module-level doc on `authorization.rs` explaining the 4-level namespace-aware ACL priority chain
- Performance analysis comment on `policy_decision_point()` documenting that namespace checks are O(1) with no allocation/lock/syscall
- Document O(n) cost of `active_connections_count()` — acceptable because it's only called from admin queries (infrequent, not on message hot path)

## Design Decision
Atomic counter for connection counting was evaluated but rejected: instrumenting face add/remove would require changes across all 4 HAT implementations (router, client, p2p_peer, linkstate_peer) for negligible gain on an admin-only endpoint.

## Testing
- `cargo check -p zenoh --features unstable` clean
- `cargo clippy -p zenoh --features unstable -- -D warnings` clean
- Documentation only — no behavior change

Closes #82