### PR TITLE
feat: SchemaVersion attachment for version negotiation (#88)

### DIFF
--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -67,7 +67,8 @@ pub use crate::serialization::{
 };
 pub use crate::typed::{
     TypedGetFuture, TypedPublisher, TypedPublisherBuilder, TypedQuery, TypedQueryable,
-    TypedQueryableBuilder, TypedSessionExt, TypedSubscriber, TypedSubscriberBuilder,
+    TypedQueryableBuilder, TypedReceiveError, TypedSessionExt, TypedSubscriber,
+    TypedSubscriberBuilder,
 };
 #[cfg(feature = "unstable")]
 #[allow(deprecated)]

--- a/zenoh-ext/src/typed.rs
+++ b/zenoh-ext/src/typed.rs
@@ -36,12 +36,93 @@ use zenoh::{
 
 use crate::{z_deserialize, z_serialize, Deserialize, Serialize, ZDeserializeError};
 
+/// Error type for typed receive operations that include version checking.
+#[derive(Debug)]
+pub enum TypedReceiveError {
+    /// The publisher's schema version doesn't match the subscriber's expected version.
+    VersionMismatch {
+        expected: u32,
+        received: u32,
+        type_name: String,
+    },
+    /// The payload could not be deserialized into the expected type.
+    DeserializationFailed(ZDeserializeError),
+}
+
+impl std::fmt::Display for TypedReceiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VersionMismatch {
+                expected,
+                received,
+                type_name,
+            } => write!(
+                f,
+                "schema version mismatch for {type_name}: expected {expected}, received {received}"
+            ),
+            Self::DeserializationFailed(e) => write!(f, "deserialization failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TypedReceiveError {}
+
+impl From<ZDeserializeError> for TypedReceiveError {
+    fn from(e: ZDeserializeError) -> Self {
+        Self::DeserializationFailed(e)
+    }
+}
+
+/// Encode a schema version into a ZBytes attachment value.
+fn encode_schema_version(version: u32) -> ZBytes {
+    ZBytes::from(version.to_le_bytes().to_vec())
+}
+
+/// Decode a schema version from a ZBytes attachment value.
+fn decode_schema_version(zbytes: &ZBytes) -> Option<u32> {
+    let bytes = zbytes.to_bytes();
+    if bytes.len() == 4 {
+        Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    } else {
+        None
+    }
+}
+
+/// Check if a sample's attachment carries a matching schema version.
+/// Returns Ok(()) if version matches or no version checking is configured.
+/// Returns Err(TypedReceiveError::VersionMismatch) on mismatch.
+fn check_schema_version<T>(
+    sample: &Sample,
+    expected_version: Option<u32>,
+) -> Result<(), TypedReceiveError> {
+    let expected = match expected_version {
+        Some(v) => v,
+        None => return Ok(()), // No version checking configured
+    };
+
+    // Check if sample has a version attachment
+    if let Some(attachment) = sample.attachment() {
+        if let Some(received) = decode_schema_version(attachment) {
+            if received != expected {
+                return Err(TypedReceiveError::VersionMismatch {
+                    expected,
+                    received,
+                    type_name: std::any::type_name::<T>().to_string(),
+                });
+            }
+        }
+    }
+    // No attachment = no version check (backward compatible)
+    Ok(())
+}
+
 /// A publisher that only accepts payloads of type `T`.
 ///
 /// Wraps a [`Publisher`] and serializes `T` via [`ZSerializer`](crate::ZSerializer)
 /// on each `put()`. Attempting to publish a wrong type is a compile error.
 pub struct TypedPublisher<'a, T: Serialize> {
     inner: Publisher<'a>,
+    schema_version: Option<u32>,
     _phantom: PhantomData<T>,
 }
 
@@ -49,7 +130,11 @@ impl<T: Serialize> TypedPublisher<'_, T> {
     /// Publish a typed payload.
     pub async fn put(&self, payload: &T) -> ZResult<()> {
         let zbytes = z_serialize(payload);
-        self.inner.put(zbytes).await
+        let mut builder = self.inner.put(zbytes);
+        if let Some(version) = self.schema_version {
+            builder = builder.attachment(encode_schema_version(version));
+        }
+        builder.await
     }
 
     /// Returns the [`KeyExpr`] this publisher publishes to.
@@ -72,6 +157,7 @@ impl<T: Serialize> TypedPublisher<'_, T> {
 /// Use [`TypedSubscriberBuilder::with`] to specify a custom handler.
 pub struct TypedSubscriber<T: Deserialize, Handler = FifoChannelHandler<Sample>> {
     inner: Subscriber<Handler>,
+    schema_version: Option<u32>,
     _phantom: PhantomData<T>,
 }
 
@@ -79,16 +165,24 @@ impl<T: Deserialize> TypedSubscriber<T, FifoChannelHandler<Sample>> {
     /// Wait for an incoming typed message.
     ///
     /// The outer `ZResult` fails only if the channel is closed.
-    /// The inner `Result` indicates deserialization success/failure.
-    pub async fn recv_async(&self) -> ZResult<Result<T, ZDeserializeError>> {
+    /// The inner `Result` indicates deserialization success/failure,
+    /// or a version mismatch if schema versioning is configured.
+    pub async fn recv_async(&self) -> ZResult<Result<T, TypedReceiveError>> {
         let sample = self.inner.recv_async().await?;
-        Ok(z_deserialize::<T>(sample.payload()))
+        Ok(self.deserialize_sample(&sample))
     }
 
     /// Blocking receive for an incoming typed message.
-    pub fn recv(&self) -> ZResult<Result<T, ZDeserializeError>> {
+    pub fn recv(&self) -> ZResult<Result<T, TypedReceiveError>> {
         let sample = self.inner.recv()?;
-        Ok(z_deserialize::<T>(sample.payload()))
+        Ok(self.deserialize_sample(&sample))
+    }
+}
+
+impl<T: Deserialize, Handler> TypedSubscriber<T, Handler> {
+    fn deserialize_sample(&self, sample: &Sample) -> Result<T, TypedReceiveError> {
+        check_schema_version::<T>(sample, self.schema_version)?;
+        z_deserialize::<T>(sample.payload()).map_err(TypedReceiveError::from)
     }
 }
 
@@ -108,10 +202,21 @@ impl<T: Deserialize, Handler> TypedSubscriber<T, Handler> {
 pub struct TypedPublisherBuilder<'a, 'b, T: Serialize> {
     session: &'a Session,
     key_expr: ZResult<KeyExpr<'b>>,
+    schema_version: Option<u32>,
     _phantom: PhantomData<T>,
 }
 
-impl<'b, T: Serialize> TypedPublisherBuilder<'_, 'b, T> {
+impl<'a, 'b, T: Serialize> TypedPublisherBuilder<'a, 'b, T> {
+    /// Set the schema version for this publisher.
+    ///
+    /// When set, the version is attached to every publication as metadata.
+    /// Subscribers with a matching expected version will accept the message;
+    /// subscribers expecting a different version will reject it.
+    pub fn schema_version(mut self, version: u32) -> Self {
+        self.schema_version = Some(version);
+        self
+    }
+
     fn build(self) -> ZResult<TypedPublisher<'b, T>> {
         let key_expr = self.key_expr?;
         let encoding =
@@ -123,6 +228,7 @@ impl<'b, T: Serialize> TypedPublisherBuilder<'_, 'b, T> {
             .wait()?;
         Ok(TypedPublisher {
             inner,
+            schema_version: self.schema_version,
             _phantom: PhantomData,
         })
     }
@@ -145,21 +251,39 @@ pub struct TypedSubscriberBuilder<'a, 'b, T: Deserialize, Handler = DefaultHandl
     session: &'a Session,
     key_expr: ZResult<KeyExpr<'b>>,
     handler: Handler,
+    schema_version: Option<u32>,
     _phantom: PhantomData<T>,
+}
+
+impl<'a, 'b, T: Deserialize, Handler> TypedSubscriberBuilder<'a, 'b, T, Handler> {
+    /// Set the expected schema version for this subscriber.
+    ///
+    /// When set, incoming messages with a mismatched version attachment
+    /// will yield [`TypedReceiveError::VersionMismatch`] without attempting
+    /// deserialization. Messages without a version attachment are accepted
+    /// (backward compatible).
+    pub fn schema_version(mut self, version: u32) -> Self {
+        self.schema_version = Some(version);
+        self
+    }
 }
 
 impl<'a, 'b, T: Deserialize> TypedSubscriberBuilder<'a, 'b, T, DefaultHandler> {
     /// Specify a custom handler for this subscriber.
     ///
     /// The handler must implement [`IntoHandler<Sample>`].
-    pub fn with<Handler>(self, handler: Handler) -> TypedSubscriberBuilder<'a, 'b, T, Handler>
+    pub fn with<NewHandler>(
+        self,
+        handler: NewHandler,
+    ) -> TypedSubscriberBuilder<'a, 'b, T, NewHandler>
     where
-        Handler: zenoh::handlers::IntoHandler<Sample>,
+        NewHandler: zenoh::handlers::IntoHandler<Sample>,
     {
         TypedSubscriberBuilder {
             session: self.session,
             key_expr: self.key_expr,
             handler,
+            schema_version: self.schema_version,
             _phantom: PhantomData,
         }
     }
@@ -179,6 +303,7 @@ where
             .wait()?;
         Ok(TypedSubscriber {
             inner,
+            schema_version: self.schema_version,
             _phantom: PhantomData,
         })
     }
@@ -364,6 +489,7 @@ impl TypedSessionExt for Session {
         TypedPublisherBuilder {
             session: self,
             key_expr: key_expr.try_into().map_err(Into::into),
+            schema_version: None,
             _phantom: PhantomData,
         }
     }
@@ -380,6 +506,7 @@ impl TypedSessionExt for Session {
             session: self,
             key_expr: key_expr.try_into().map_err(Into::into),
             handler: DefaultHandler::default(),
+            schema_version: None,
             _phantom: PhantomData,
         }
     }

--- a/zenoh-ext/tests/typed.rs
+++ b/zenoh-ext/tests/typed.rs
@@ -328,3 +328,124 @@ async fn typed_queryable_malformed_request_yields_err() {
     drop(replies);
     handle.await.unwrap();
 }
+
+// -- SchemaVersion tests --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_pub_sub_with_schema_version_match() {
+    use zenoh_ext::TypedSessionExt;
+
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    let subscriber = session
+        .declare_typed_subscriber::<TelemetryPayload, _>("test/typed/version/match")
+        .schema_version(3)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let publisher = session
+        .declare_typed_publisher::<TelemetryPayload, _>("test/typed/version/match")
+        .schema_version(3)
+        .await
+        .unwrap();
+
+    let payload = TelemetryPayload {
+        device_id: 1,
+        temperature: 20.0,
+        label: "versioned".to_string(),
+    };
+    publisher.put(&payload).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(5), subscriber.recv_async())
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+
+    // Version matches — should get Ok
+    assert!(received.is_ok());
+    assert_eq!(received.unwrap(), payload);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_pub_sub_version_mismatch_yields_err() {
+    use zenoh_ext::TypedSessionExt;
+
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    let subscriber = session
+        .declare_typed_subscriber::<TelemetryPayload, _>("test/typed/version/mismatch")
+        .schema_version(3)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let publisher = session
+        .declare_typed_publisher::<TelemetryPayload, _>("test/typed/version/mismatch")
+        .schema_version(2) // Different version!
+        .await
+        .unwrap();
+
+    let payload = TelemetryPayload {
+        device_id: 1,
+        temperature: 20.0,
+        label: "wrong-version".to_string(),
+    };
+    publisher.put(&payload).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(5), subscriber.recv_async())
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+
+    // Version mismatch — should get Err with VersionMismatch
+    assert!(received.is_err());
+    let err = received.unwrap_err();
+    match err {
+        zenoh_ext::TypedReceiveError::VersionMismatch { expected, received, .. } => {
+            assert_eq!(expected, 3);
+            assert_eq!(received, 2);
+        }
+        other => panic!("Expected VersionMismatch, got: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_sub_no_version_attachment_degrades_gracefully() {
+    use zenoh_ext::TypedSessionExt;
+
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    // Subscriber expects version 3
+    let subscriber = session
+        .declare_typed_subscriber::<TelemetryPayload, _>("test/typed/version/noattach")
+        .schema_version(3)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Publisher WITHOUT schema_version (no version attachment)
+    let publisher = session
+        .declare_typed_publisher::<TelemetryPayload, _>("test/typed/version/noattach")
+        .await
+        .unwrap();
+
+    let payload = TelemetryPayload {
+        device_id: 5,
+        temperature: 15.0,
+        label: "no-version".to_string(),
+    };
+    publisher.put(&payload).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(5), subscriber.recv_async())
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+
+    // No version attachment — should attempt deserialization and succeed
+    assert!(received.is_ok());
+    assert_eq!(received.unwrap(), payload);
+}


### PR DESCRIPTION
## Summary

- Add `TypedReceiveError` enum with `VersionMismatch` and `DeserializationFailed` variants
- Add `.schema_version(u32)` to `TypedPublisherBuilder` and `TypedSubscriberBuilder`
- Publisher attaches version as `ZBytes` metadata on each `put()`
- Subscriber checks version before deserializing — mismatch = fast rejection without deserialization
- Messages without version attachment accepted (backward compatible with unversioned publishers)

## Changes

- `zenoh-ext/src/typed.rs` — `TypedReceiveError`, version encode/decode, `check_schema_version()`, builder extensions
- `zenoh-ext/src/lib.rs` — export `TypedReceiveError`
- `zenoh-ext/tests/typed.rs` — 3 new tests

## Testing

- `typed_pub_sub_with_schema_version_match` — matching versions, successful delivery
- `typed_pub_sub_version_mismatch_yields_err` — v2 publisher vs v3 subscriber, VersionMismatch error
- `typed_sub_no_version_attachment_degrades_gracefully` — unversioned publisher to versioned subscriber, works
- All 10 typed tests pass, 8 lib unit tests pass
- `cargo clippy -p zenoh-ext -- -D warnings` clean

Closes #88