### PR TITLE
test: schema enforcement integration tests (#89)

### DIFF
--- a/zenoh-ext/tests/typed.rs
+++ b/zenoh-ext/tests/typed.rs
@@ -449,3 +449,48 @@ async fn typed_sub_no_version_attachment_degrades_gracefully() {
     assert!(received.is_ok());
     assert_eq!(received.unwrap(), payload);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_publisher_to_untyped_subscriber_backward_compat() {
+    use zenoh_ext::TypedSessionExt;
+
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    // Untyped subscriber receives raw samples
+    let subscriber = session
+        .declare_subscriber("test/typed/backward/typed2untyped")
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Typed publisher with schema version
+    let publisher = session
+        .declare_typed_publisher::<TelemetryPayload, _>("test/typed/backward/typed2untyped")
+        .schema_version(3)
+        .await
+        .unwrap();
+
+    let payload = TelemetryPayload {
+        device_id: 77,
+        temperature: 18.5,
+        label: "backward-compat".to_string(),
+    };
+    publisher.put(&payload).await.unwrap();
+
+    let sample = tokio::time::timeout(Duration::from_secs(5), subscriber.recv_async())
+        .await
+        .expect("timeout")
+        .expect("channel closed");
+
+    // Untyped subscriber gets valid ZBytes — version attachment is ignorable metadata
+    assert!(!sample.payload().is_empty());
+
+    // Can manually deserialize
+    let deserialized: TelemetryPayload =
+        zenoh_ext::z_deserialize(sample.payload()).expect("manual deserialization should work");
+    assert_eq!(deserialized, payload);
+
+    // Attachment is present (contains the version)
+    assert!(sample.attachment().is_some());
+}


### PR DESCRIPTION
## Summary

- Add `typed_publisher_to_untyped_subscriber_backward_compat` — the final missing test from the M6 integration test spec
- Verifies typed publisher with schema version can publish to a raw subscriber without breaking
- Confirms version attachment is ignorable metadata, payload is valid ZBytes, manual deserialization works

## Coverage

All 9 scenarios from the #89 spec are now covered across 11 integration tests:

1. Typed pub/sub round-trip (#86)
2. Type mismatch detection (#86)
3. Version match (#88)
4. Version mismatch (#88)
5. Backward compat: untyped → typed (#88)
6. **Backward compat: typed → untyped** (this PR)
7. Typed query/reply round-trip (#87)
8. Wildcard typed queryable (#87)
9. Error path: queryable can't parse request (#87)

Plus 2 additional: multiple messages, blocking recv.

All 11 tests pass. Clippy clean.

Closes #89