### PR TITLE
fix: replace std::any::type_name with stable TypedSchema trait

### DIFF
--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::serialization::{
     ZReadIter, ZSerializer,
 };
 pub use crate::typed::{
-    TypedPublisher, TypedPublisherBuilder, TypedSessionExt, TypedSubscriber,
+    TypedPublisher, TypedPublisherBuilder, TypedSchema, TypedSessionExt, TypedSubscriber,
     TypedSubscriberBuilder,
 };
 #[cfg(feature = "unstable")]

--- a/zenoh-ext/src/typed.rs
+++ b/zenoh-ext/src/typed.rs
@@ -35,16 +35,37 @@ use zenoh::{
 
 use crate::{z_deserialize, z_serialize, Deserialize, Serialize, ZDeserializeError};
 
+/// Provides a stable, cross-language identifier for typed pub/sub encoding.
+///
+/// Implementors choose a name that is consistent across all participants
+/// (including non-Rust clients). This replaces the use of [`std::any::type_name`],
+/// whose output is not guaranteed stable across compiler versions.
+///
+/// # Example
+/// ```
+/// use zenoh_ext::TypedSchema;
+///
+/// struct Telemetry { /* ... */ }
+///
+/// impl TypedSchema for Telemetry {
+///     const SCHEMA_NAME: &'static str = "com.example.telemetry.v1";
+/// }
+/// ```
+pub trait TypedSchema {
+    /// A stable, unique identifier for this type's wire encoding.
+    const SCHEMA_NAME: &'static str;
+}
+
 /// A publisher that only accepts payloads of type `T`.
 ///
 /// Wraps a [`Publisher`] and serializes `T` via [`ZSerializer`](crate::ZSerializer)
 /// on each `put()`. Attempting to publish a wrong type is a compile error.
-pub struct TypedPublisher<'a, T: Serialize> {
+pub struct TypedPublisher<'a, T: Serialize + TypedSchema> {
     inner: Publisher<'a>,
     _phantom: PhantomData<T>,
 }
 
-impl<T: Serialize> TypedPublisher<'_, T> {
+impl<T: Serialize + TypedSchema> TypedPublisher<'_, T> {
     /// Publish a typed payload.
     pub async fn put(&self, payload: &T) -> ZResult<()> {
         let zbytes = z_serialize(payload);
@@ -66,12 +87,12 @@ impl<T: Serialize> TypedPublisher<'_, T> {
 ///
 /// Wraps a [`Subscriber`] and yields `Result<T, ZDeserializeError>` on each
 /// received sample. Malformed payloads yield `Err`, never panic.
-pub struct TypedSubscriber<T: Deserialize> {
+pub struct TypedSubscriber<T: Deserialize + TypedSchema> {
     inner: Subscriber<FifoChannelHandler<Sample>>,
     _phantom: PhantomData<T>,
 }
 
-impl<T: Deserialize> TypedSubscriber<T> {
+impl<T: Deserialize + TypedSchema> TypedSubscriber<T> {
     /// Wait for an incoming typed message.
     ///
     /// The outer `ZResult` fails only if the channel is closed.
@@ -94,17 +115,16 @@ impl<T: Deserialize> TypedSubscriber<T> {
 }
 
 /// Builder for [`TypedPublisher`].
-pub struct TypedPublisherBuilder<'a, 'b, T: Serialize> {
+pub struct TypedPublisherBuilder<'a, 'b, T: Serialize + TypedSchema> {
     session: &'a Session,
     key_expr: ZResult<KeyExpr<'b>>,
     _phantom: PhantomData<T>,
 }
 
-impl<'b, T: Serialize> TypedPublisherBuilder<'_, 'b, T> {
+impl<'b, T: Serialize + TypedSchema> TypedPublisherBuilder<'_, 'b, T> {
     fn build(self) -> ZResult<TypedPublisher<'b, T>> {
         let key_expr = self.key_expr?;
-        let encoding =
-            Encoding::from(format!("zenoh-ext/typed:{}", std::any::type_name::<T>()));
+        let encoding = Encoding::from(format!("zenoh-ext/typed:{}", T::SCHEMA_NAME));
         let inner = self
             .session
             .declare_publisher(key_expr)
@@ -117,7 +137,7 @@ impl<'b, T: Serialize> TypedPublisherBuilder<'_, 'b, T> {
     }
 }
 
-impl<'b, T: Serialize> IntoFuture for TypedPublisherBuilder<'_, 'b, T> {
+impl<'b, T: Serialize + TypedSchema> IntoFuture for TypedPublisherBuilder<'_, 'b, T> {
     type Output = ZResult<TypedPublisher<'b, T>>;
     type IntoFuture = Ready<Self::Output>;
 
@@ -127,13 +147,13 @@ impl<'b, T: Serialize> IntoFuture for TypedPublisherBuilder<'_, 'b, T> {
 }
 
 /// Builder for [`TypedSubscriber`].
-pub struct TypedSubscriberBuilder<'a, 'b, T: Deserialize> {
+pub struct TypedSubscriberBuilder<'a, 'b, T: Deserialize + TypedSchema> {
     session: &'a Session,
     key_expr: ZResult<KeyExpr<'b>>,
     _phantom: PhantomData<T>,
 }
 
-impl<T: Deserialize> TypedSubscriberBuilder<'_, '_, T> {
+impl<T: Deserialize + TypedSchema> TypedSubscriberBuilder<'_, '_, T> {
     fn build(self) -> ZResult<TypedSubscriber<T>> {
         let key_expr = self.key_expr?;
         let inner = self.session.declare_subscriber(key_expr).wait()?;
@@ -144,7 +164,7 @@ impl<T: Deserialize> TypedSubscriberBuilder<'_, '_, T> {
     }
 }
 
-impl<T: Deserialize> IntoFuture for TypedSubscriberBuilder<'_, '_, T> {
+impl<T: Deserialize + TypedSchema> IntoFuture for TypedSubscriberBuilder<'_, '_, T> {
     type Output = ZResult<TypedSubscriber<T>>;
     type IntoFuture = Ready<Self::Output>;
 
@@ -156,7 +176,7 @@ impl<T: Deserialize> IntoFuture for TypedSubscriberBuilder<'_, '_, T> {
 /// Extension trait for [`Session`] to declare typed publishers and subscribers.
 pub trait TypedSessionExt {
     /// Declare a [`TypedPublisher`] for the given key expression.
-    fn declare_typed_publisher<'b, T: Serialize, TryIntoKeyExpr>(
+    fn declare_typed_publisher<'b, T: Serialize + TypedSchema, TryIntoKeyExpr>(
         &self,
         key_expr: TryIntoKeyExpr,
     ) -> TypedPublisherBuilder<'_, 'b, T>
@@ -165,7 +185,7 @@ pub trait TypedSessionExt {
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<Error>;
 
     /// Declare a [`TypedSubscriber`] for the given key expression.
-    fn declare_typed_subscriber<'b, T: Deserialize, TryIntoKeyExpr>(
+    fn declare_typed_subscriber<'b, T: Deserialize + TypedSchema, TryIntoKeyExpr>(
         &self,
         key_expr: TryIntoKeyExpr,
     ) -> TypedSubscriberBuilder<'_, 'b, T>
@@ -175,7 +195,7 @@ pub trait TypedSessionExt {
 }
 
 impl TypedSessionExt for Session {
-    fn declare_typed_publisher<'b, T: Serialize, TryIntoKeyExpr>(
+    fn declare_typed_publisher<'b, T: Serialize + TypedSchema, TryIntoKeyExpr>(
         &self,
         key_expr: TryIntoKeyExpr,
     ) -> TypedPublisherBuilder<'_, 'b, T>
@@ -190,7 +210,7 @@ impl TypedSessionExt for Session {
         }
     }
 
-    fn declare_typed_subscriber<'b, T: Deserialize, TryIntoKeyExpr>(
+    fn declare_typed_subscriber<'b, T: Deserialize + TypedSchema, TryIntoKeyExpr>(
         &self,
         key_expr: TryIntoKeyExpr,
     ) -> TypedSubscriberBuilder<'_, 'b, T>

--- a/zenoh-ext/tests/typed.rs
+++ b/zenoh-ext/tests/typed.rs
@@ -14,7 +14,9 @@
 
 use std::time::Duration;
 
-use zenoh_ext::{Deserialize, Serialize, ZDeserializeError, ZDeserializer, ZSerializer};
+use zenoh_ext::{
+    Deserialize, Serialize, TypedSchema, ZDeserializeError, ZDeserializer, ZSerializer,
+};
 
 // -- Test payload types --
 
@@ -41,6 +43,10 @@ impl Deserialize for TelemetryPayload {
             label: deserializer.deserialize()?,
         })
     }
+}
+
+impl TypedSchema for TelemetryPayload {
+    const SCHEMA_NAME: &'static str = "test.telemetry.v1";
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -108,7 +114,7 @@ async fn typed_subscriber_malformed_payload_yields_err() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn typed_publisher_sets_encoding() {
+async fn typed_publisher_encoding_uses_schema_name() {
     use zenoh_ext::TypedSessionExt;
 
     let session = zenoh::open(zenoh::Config::default()).await.unwrap();
@@ -120,9 +126,38 @@ async fn typed_publisher_sets_encoding() {
 
     let encoding = publisher.encoding();
     let encoding_str = format!("{encoding}");
+    // Encoding must use the user-provided SCHEMA_NAME, not std::any::type_name
+    assert_eq!(
+        encoding_str, "zenoh-ext/typed:test.telemetry.v1",
+        "Encoding should use TypedSchema::SCHEMA_NAME, got: {encoding_str}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_encoding_is_stable_across_builds() {
+    use zenoh_ext::TypedSessionExt;
+
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    // Create two publishers for the same type — encoding must be identical and deterministic
+    let pub1 = session
+        .declare_typed_publisher::<TelemetryPayload, _>("test/typed/stable1")
+        .await
+        .unwrap();
+    let pub2 = session
+        .declare_typed_publisher::<TelemetryPayload, _>("test/typed/stable2")
+        .await
+        .unwrap();
+
+    let enc1 = format!("{}", pub1.encoding());
+    let enc2 = format!("{}", pub2.encoding());
+
+    assert_eq!(enc1, enc2, "Same type must produce identical encoding");
+
+    // Encoding must NOT contain Rust-specific module paths (the old type_name behavior)
     assert!(
-        encoding_str.contains("typed"),
-        "Encoding should contain 'typed' marker, got: {encoding_str}"
+        !enc1.contains("::"),
+        "Encoding must not contain Rust module paths (::), got: {enc1}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Adds `TypedSchema` trait with `const SCHEMA_NAME: &'static str` for stable, cross-language type identification
- Replaces unstable `std::any::type_name::<T>()` with user-provided `T::SCHEMA_NAME` in encoding format
- All typed pub/sub wrappers now require `T: TypedSchema` bound

## Changes
- `zenoh-ext/src/typed.rs`: New `TypedSchema` trait, updated all bounds from `Serialize`/`Deserialize` to include `+ TypedSchema`, encoding now uses `T::SCHEMA_NAME`
- `zenoh-ext/src/lib.rs`: Export `TypedSchema`
- `zenoh-ext/tests/typed.rs`: Added `TypedSchema` impl for test type, new encoding stability tests

## Testing
- 6/6 typed tests pass
- `typed_publisher_encoding_uses_schema_name` — verifies encoding uses exact schema name
- `typed_encoding_is_stable_across_builds` — verifies determinism and absence of Rust module paths
- Clippy clean on lib + tests

Closes #120