### PR TITLE
feat: configurable connection limits via max_connections

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -876,6 +876,12 @@ validated_struct::validator! {
         /// will put a message into "1/my/keyexpr". Same applies to all other operations within this session.
         pub namespace: Option<OwnedNonWildKeyExpr>,
 
+        /// Maximum number of transport connections allowed.
+        /// When set, new connections beyond this limit will be rejected.
+        ///
+        /// **Unstable** — this field may change or be removed before stabilization.
+        pub max_connections: Option<usize>,
+
         /// Configuration of the downsampling.
         downsampling: Vec<DownsamplingItemConf> where (downsampling_validator),
 

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -336,4 +336,17 @@ pub(crate) fn on_admin_query(
             reply(match_prefix, reply_prefix, &ke_link, &query, &link_json);
         }
     }
+
+    // Connection status summary
+    if let Some(runtime) = session.runtime().static_runtime() {
+        let mut conn_json = serde_json::json!({
+            "active_connections": runtime.active_connections_count(),
+        });
+        if let Some(max) = runtime.max_connections() {
+            conn_json["max_connections"] = serde_json::json!(max);
+        }
+        // SAFETY: "connections" is a valid key expression (no wildcards or special chars).
+        let ke_connections = unsafe { keyexpr::from_str_unchecked("connections") };
+        reply(match_prefix, reply_prefix, ke_connections, &query, &conn_json);
+    }
 }

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -124,6 +124,7 @@ pub(crate) struct RuntimeState {
     start_conditions: Arc<StartConditions>,
     pending_connections: tokio::sync::Mutex<HashSet<ZenohIdProto>>,
     namespace: Option<OwnedNonWildKeyExpr>,
+    max_connections: Option<usize>,
     #[cfg(feature = "stats")]
     stats: zenoh_stats::StatsRegistry,
 }
@@ -555,12 +556,23 @@ impl RuntimeBuilder {
 
     pub async fn build(self) -> ZResult<Runtime> {
         let RuntimeBuilder {
-            config,
+            mut config,
             #[cfg(feature = "plugins")]
             mut plugins_manager,
             #[cfg(feature = "shared-memory")]
             shm_clients,
         } = self;
+
+        // Map max_connections to the transport layer's max_sessions, which rejects
+        // connections during the protocol handshake (before OPEN ACK). We inject into
+        // the config because TransportManager::builder().from_config() reads max_sessions
+        // from config — there is no direct setter on the builder.
+        if let Some(max) = *config.max_connections() {
+            tracing::info!("max_connections={max}, mapping to transport/unicast/max_sessions");
+            config
+                .insert_json5("transport/unicast/max_sessions", &max.to_string())
+                .map_err(|e| zerror!("Failed to set max_sessions from max_connections: {}", e))?;
+        }
 
         tracing::debug!("Zenoh Rust API {}", GIT_VERSION);
         let zid = (*config.id()).unwrap_or_default().into();
@@ -615,6 +627,7 @@ impl RuntimeBuilder {
         let shm_init_mode = *config.transport.shared_memory.mode();
 
         let namespace = config.namespace().clone();
+        let max_connections = *config.max_connections();
         let config = Notifier::new(crate::config::Config(config));
 
         let runtime = Runtime {
@@ -634,6 +647,7 @@ impl RuntimeBuilder {
                 start_conditions: Arc::new(StartConditions::default()),
                 pending_connections: tokio::sync::Mutex::new(HashSet::new()),
                 namespace,
+                max_connections,
                 #[cfg(feature = "stats")]
                 stats,
             }),
@@ -778,6 +792,23 @@ impl Runtime {
     #[allow(dead_code)]
     pub fn get_shm_provider(&self) -> ShmProviderState {
         self.state.get_shm_provider()
+    }
+
+    pub(crate) fn max_connections(&self) -> Option<usize> {
+        self.state.max_connections
+    }
+
+    /// Returns the number of active non-local connections (faces).
+    ///
+    /// **Complexity**: O(n) — acquires a read lock on `router.tables.tables` and
+    /// iterates all faces. This is acceptable because the method is only called
+    /// from admin space queries, which are infrequent. Introducing an `AtomicUsize`
+    /// counter would require instrumenting face add/remove across all four HAT
+    /// implementations (router, client, p2p_peer, linkstate_peer), adding coupling
+    /// for negligible gain on an infrequent code path.
+    pub(crate) fn active_connections_count(&self) -> usize {
+        let tables = zread!(self.state.router.tables.tables);
+        tables.faces.values().filter(|f| !f.is_local).count()
     }
 
     pub(crate) fn start_conditions(&self) -> &Arc<StartConditions> {

--- a/zenoh/tests/namespace.rs
+++ b/zenoh/tests/namespace.rs
@@ -679,3 +679,153 @@ async fn zenoh_namespace_queryable_get_routed_clients() -> ZResult<()> {
     ));
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Per-namespace connection limits (Issue #44)
+// ---------------------------------------------------------------------------
+
+/// Helper: create a router config with max_connections set.
+async fn get_router_config_with_max_connections(
+    port: u16,
+    max_connections: usize,
+) -> zenoh_config::Config {
+    let mut config = zenoh_config::Config::default();
+    config.set_mode(Some(WhatAmI::Router)).unwrap();
+    config
+        .listen
+        .endpoints
+        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    // Set the per-namespace connection limit.
+    config
+        .insert_json5("max_connections", &max_connections.to_string())
+        .unwrap();
+    config
+}
+
+/// Helper: create a basic client config pointing at the given port.
+async fn get_client_config(port: u16) -> zenoh_config::Config {
+    let mut config = zenoh_config::Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .set_endpoints(ModeDependentValue::Unique(vec![
+            format!("tcp/127.0.0.1:{port}").parse().unwrap(),
+        ]))
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config
+}
+
+/// When max_connections is set to 2, a 3rd client connection must be rejected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_max_connections_rejects_excess() -> ZResult<()> {
+    zenoh_util::init_log_from_env_or("error");
+
+    let router_config = get_router_config_with_max_connections(19201, 2).await;
+    let _router = ztimeout!(zenoh::open(router_config)).unwrap();
+
+    // First two clients should connect successfully.
+    let _client1 = ztimeout!(zenoh::open(get_client_config(19201).await)).unwrap();
+    let _client2 = ztimeout!(zenoh::open(get_client_config(19201).await)).unwrap();
+
+    // Third client must be rejected because max_connections=2.
+    let result = ztimeout!(zenoh::open(get_client_config(19201).await));
+    assert!(
+        result.is_err(),
+        "Expected 3rd connection to be rejected when max_connections=2"
+    );
+
+    // Clean up.
+    ztimeout!(_client1.close()).unwrap();
+    ztimeout!(_client2.close()).unwrap();
+    ztimeout!(_router.close()).unwrap();
+    Ok(())
+}
+
+/// When max_connections is not set (default), any number of clients can connect.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_no_max_connections_unlimited() -> ZResult<()> {
+    zenoh_util::init_log_from_env_or("error");
+
+    // Router WITHOUT max_connections — default unlimited.
+    let mut router_config = zenoh_config::Config::default();
+    router_config.set_mode(Some(WhatAmI::Router)).unwrap();
+    router_config
+        .listen
+        .endpoints
+        .set(vec!["tcp/127.0.0.1:19202".parse().unwrap()])
+        .unwrap();
+    router_config
+        .scouting
+        .multicast
+        .set_enabled(Some(false))
+        .unwrap();
+
+    let _router = ztimeout!(zenoh::open(router_config)).unwrap();
+
+    // Connect 4 clients — all should succeed.
+    let mut clients = Vec::new();
+    for _ in 0..4 {
+        let client = ztimeout!(zenoh::open(get_client_config(19202).await)).unwrap();
+        clients.push(client);
+    }
+
+    // Clean up.
+    for client in clients {
+        ztimeout!(client.close()).unwrap();
+    }
+    ztimeout!(_router.close()).unwrap();
+    Ok(())
+}
+
+/// The admin space should expose active_connections and max_connections.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_max_connections_admin_status() -> ZResult<()> {
+    zenoh_util::init_log_from_env_or("error");
+
+    let router_config = get_router_config_with_max_connections(19203, 5).await;
+    let router = ztimeout!(zenoh::open(router_config)).unwrap();
+
+    // Connect one client.
+    let client = ztimeout!(zenoh::open(get_client_config(19203).await)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+
+    // Query admin space for router info — admin keys are @/{zid}/{whatami}
+    let replies = ztimeout!(router.get("@/**")).unwrap();
+
+    let mut found_connections_info = false;
+    while let Ok(reply) = replies.recv_async().await {
+        if let Ok(sample) = reply.result() {
+            let payload = sample
+                .payload()
+                .try_to_string()
+                .unwrap_or_default()
+                .to_string();
+            if payload.contains("active_connections") {
+                found_connections_info = true;
+                assert!(
+                    payload.contains("\"active_connections\":1")
+                        || payload.contains("\"active_connections\": 1"),
+                    "Expected active_connections to be 1, got: {payload}"
+                );
+                assert!(
+                    payload.contains("\"max_connections\":5")
+                        || payload.contains("\"max_connections\": 5"),
+                    "Expected max_connections to be 5, got: {payload}"
+                );
+            }
+        }
+    }
+    assert!(
+        found_connections_info,
+        "Admin space should expose active_connections and max_connections"
+    );
+
+    // Clean up.
+    ztimeout!(client.close()).unwrap();
+    ztimeout!(router.close()).unwrap();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Extract connection-limit-only changes from `zenoh/namespace-isolation` branch as a clean, minimal PR
- Add `max_connections: Option<usize>` config field (unstable) that maps to transport `max_sessions` to reject connections during OPEN handshake
- Admin space exposes `active_connections` and `max_connections` at `@/{zid}/connections`

## Changes
- `commons/zenoh-config/src/lib.rs` — new `max_connections` config field
- `zenoh/src/net/runtime/mod.rs` — max_connections state, mapping to max_sessions, `active_connections_count()` method
- `zenoh/src/api/admin.rs` — connection status in admin space
- `zenoh/tests/namespace.rs` — 3 integration tests (rejection at limit, unlimited default, admin status)

## Testing
- `test_max_connections_rejects_excess` — verifies 3rd client rejected when max=2
- `test_no_max_connections_unlimited` — verifies unlimited connections when unset
- `test_max_connections_admin_status` — verifies admin space exposes connection info
- All 15 namespace tests pass, no regressions
- `cargo clippy`, `cargo fmt --check` clean

Closes #124