### PR TITLE
refactor: eliminate duplicated StorageInsertionResult enum

### DIFF
--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -195,6 +195,20 @@ pub enum StorageInsertionResult {
     Deleted = 3,
 }
 
+impl TryFrom<u8> for StorageInsertionResult {
+    type Error = zenoh::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Outdated),
+            1 => Ok(Self::Inserted),
+            2 => Ok(Self::Replaced),
+            3 => Ok(Self::Deleted),
+            v => Err(format!("invalid StorageInsertionResult discriminant: {v}").into()),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StoredData {
     pub payload: ZBytes,
@@ -269,4 +283,52 @@ pub trait Storage: Send + Sync {
     /// The latest Timestamp corresponding to each key is either the timestamp of the delete or put whichever is the latest.
     /// Remember to fetch the entry corresponding to the `None` key
     async fn get_all_entries(&self) -> ZResult<Vec<(Option<OwnedKeyExpr>, Timestamp)>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_u8_valid_variants() {
+        assert_eq!(
+            StorageInsertionResult::try_from(0).unwrap(),
+            StorageInsertionResult::Outdated
+        );
+        assert_eq!(
+            StorageInsertionResult::try_from(1).unwrap(),
+            StorageInsertionResult::Inserted
+        );
+        assert_eq!(
+            StorageInsertionResult::try_from(2).unwrap(),
+            StorageInsertionResult::Replaced
+        );
+        assert_eq!(
+            StorageInsertionResult::try_from(3).unwrap(),
+            StorageInsertionResult::Deleted
+        );
+    }
+
+    #[test]
+    fn try_from_u8_invalid_returns_error() {
+        for v in [4, 5, 100, 255] {
+            assert!(
+                StorageInsertionResult::try_from(v).is_err(),
+                "expected error for discriminant {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn repr_u8_round_trip() {
+        let variants = [
+            StorageInsertionResult::Outdated,
+            StorageInsertionResult::Inserted,
+            StorageInsertionResult::Replaced,
+            StorageInsertionResult::Deleted,
+        ];
+        for v in variants {
+            assert_eq!(StorageInsertionResult::try_from(v as u8).unwrap(), v);
+        }
+    }
 }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -48,12 +48,12 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true }
 uhlc = { workspace = true }
 zenoh = { workspace = true, default-features = false }
+zenoh_backend_traits = { workspace = true }
 zenoh-macros = { workspace = true }
 zenoh-util = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
-zenoh_backend_traits = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-plugin-storage-manager = { path = "../plugins/zenoh-plugin-storage-manager" }
 zenoh-plugin-trait = { workspace = true }

--- a/zenoh-ext/src/ack_put.rs
+++ b/zenoh-ext/src/ack_put.rs
@@ -28,34 +28,7 @@ use zenoh::{
     query::{Reply, Selector},
     Result as ZResult, Session,
 };
-
-/// Result of an acknowledged storage insertion operation.
-///
-/// Mirrors the `StorageInsertionResult` from `zenoh-backend-traits` but lives
-/// in `zenoh-ext` to avoid a plugin dependency.  The wire encoding is a single
-/// `u8` discriminant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum StorageInsertionResult {
-    Outdated = 0,
-    Inserted = 1,
-    Replaced = 2,
-    Deleted = 3,
-}
-
-impl TryFrom<u8> for StorageInsertionResult {
-    type Error = zenoh::Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::Outdated),
-            1 => Ok(Self::Inserted),
-            2 => Ok(Self::Replaced),
-            3 => Ok(Self::Deleted),
-            v => Err(format!("invalid StorageInsertionResult discriminant: {v}").into()),
-        }
-    }
-}
+pub use zenoh_backend_traits::StorageInsertionResult;
 
 /// Query parameter indicating an acknowledged put.
 const ACK_PUT_PARAM: &str = "_ack_put=true";
@@ -106,12 +79,9 @@ pub async fn ack_put(
         .timeout(timeout)
         .await?;
 
-    let reply: Reply = replies
-        .recv_async()
-        .await
-        .map_err(|_| -> zenoh::Error {
-            "no ack reply received (timeout or channel closed)".into()
-        })?;
+    let reply: Reply = replies.recv_async().await.map_err(|_| -> zenoh::Error {
+        "no ack reply received (timeout or channel closed)".into()
+    })?;
 
     parse_ack_reply(reply)
 }
@@ -133,60 +103,9 @@ pub async fn ack_delete(
     let selector = Selector::owned(key_expr.clone(), ACK_DELETE_PARAM);
     let replies = session.get(selector).timeout(timeout).await?;
 
-    let reply: Reply = replies
-        .recv_async()
-        .await
-        .map_err(|_| -> zenoh::Error {
-            "no ack reply received (timeout or channel closed)".into()
-        })?;
+    let reply: Reply = replies.recv_async().await.map_err(|_| -> zenoh::Error {
+        "no ack reply received (timeout or channel closed)".into()
+    })?;
 
     parse_ack_reply(reply)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn try_from_u8_valid_variants() {
-        assert_eq!(
-            StorageInsertionResult::try_from(0).unwrap(),
-            StorageInsertionResult::Outdated
-        );
-        assert_eq!(
-            StorageInsertionResult::try_from(1).unwrap(),
-            StorageInsertionResult::Inserted
-        );
-        assert_eq!(
-            StorageInsertionResult::try_from(2).unwrap(),
-            StorageInsertionResult::Replaced
-        );
-        assert_eq!(
-            StorageInsertionResult::try_from(3).unwrap(),
-            StorageInsertionResult::Deleted
-        );
-    }
-
-    #[test]
-    fn try_from_u8_invalid_returns_error() {
-        for v in [4, 5, 100, 255] {
-            assert!(
-                StorageInsertionResult::try_from(v).is_err(),
-                "expected error for discriminant {v}"
-            );
-        }
-    }
-
-    #[test]
-    fn repr_u8_round_trip() {
-        let variants = [
-            StorageInsertionResult::Outdated,
-            StorageInsertionResult::Inserted,
-            StorageInsertionResult::Replaced,
-            StorageInsertionResult::Deleted,
-        ];
-        for v in variants {
-            assert_eq!(StorageInsertionResult::try_from(v as u8).unwrap(), v);
-        }
-    }
 }

--- a/zenoh-ext/tests/ack_put.rs
+++ b/zenoh-ext/tests/ack_put.rs
@@ -19,11 +19,7 @@
 
 use std::time::Duration;
 
-use zenoh::{
-    bytes::Encoding,
-    query::Reply,
-    Config,
-};
+use zenoh::{bytes::Encoding, query::Reply, Config};
 use zenoh_ext::{ack_delete, ack_put, StorageInsertionResult};
 use zenoh_plugin_trait::Plugin;
 
@@ -74,15 +70,9 @@ async fn ack_put_integration() {
 
     // --- Scenario 1: Basic ack'd put returns Inserted ---
     let key_a = zenoh::key_expr::KeyExpr::try_from("ack/ext/a").unwrap();
-    let result = ack_put(
-        &session,
-        &key_a,
-        "hello",
-        Encoding::TEXT_PLAIN,
-        ACK_TIMEOUT,
-    )
-    .await
-    .unwrap();
+    let result = ack_put(&session, &key_a, "hello", Encoding::TEXT_PLAIN, ACK_TIMEOUT)
+        .await
+        .unwrap();
     assert_eq!(
         result,
         StorageInsertionResult::Inserted,
@@ -158,7 +148,11 @@ async fn ack_put_integration() {
         .unwrap()
         .into_iter()
         .collect();
-    assert_eq!(replies.len(), 1, "Regular put should be retrievable via get");
+    assert_eq!(
+        replies.len(),
+        1,
+        "Regular put should be retrievable via get"
+    );
     let sample = replies[0].result().expect("Expected Ok reply");
     assert_eq!(sample.payload().try_to_string().unwrap(), "normal-value");
 
@@ -177,17 +171,4 @@ async fn ack_put_integration() {
         StorageInsertionResult::Replaced,
         "ack_put over existing value should return Replaced"
     );
-}
-
-/// Ensures the duplicated `StorageInsertionResult` in `zenoh-ext` stays in sync
-/// with the source-of-truth in `zenoh-backend-traits`.
-#[test]
-fn discriminant_parity() {
-    use zenoh_backend_traits::StorageInsertionResult as BackendResult;
-    use zenoh_ext::StorageInsertionResult as ExtResult;
-
-    assert_eq!(BackendResult::Outdated as u8, ExtResult::Outdated as u8);
-    assert_eq!(BackendResult::Inserted as u8, ExtResult::Inserted as u8);
-    assert_eq!(BackendResult::Replaced as u8, ExtResult::Replaced as u8);
-    assert_eq!(BackendResult::Deleted as u8, ExtResult::Deleted as u8);
 }


### PR DESCRIPTION
## Summary
- Move `TryFrom<u8>` impl to `zenoh-backend-traits` (single source of truth)
- Replace duplicate `StorageInsertionResult` enum in `zenoh-ext` with `pub use` re-export
- Remove `discriminant_parity` test (no longer needed — types are identical)

## Changes
- **zenoh-backend-traits**: Added `TryFrom<u8>` impl + inline unit tests for round-trip validation
- **zenoh-ext/ack_put.rs**: Removed 80+ lines of duplicated enum/impl/tests, replaced with 1-line re-export
- **zenoh-ext/Cargo.toml**: Moved `zenoh_backend_traits` from `[dev-dependencies]` to `[dependencies]` (now used in production code)
- **zenoh-ext/tests/ack_put.rs**: Removed `discriminant_parity` test

## Testing
- All acceptance criteria verified with passing tests
- 4 backend-traits tests pass (3 new TryFrom unit tests + 1 doctest)
- 9 zenoh-ext tests pass (integration tests unchanged)
- `cargo clippy`, `cargo fmt --check` clean

Closes #123