### PR TITLE
feat: namespace-aware ACL auto-deny for cross-namespace isolation

### DIFF
--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -696,11 +696,13 @@ impl IngressAclEnforcer {
 
 pub(crate) fn acl_interceptor_factories(
     acl_config: &AclConfig,
+    namespace: Option<zenoh_keyexpr::OwnedNonWildKeyExpr>,
 ) -> ZResult<Vec<InterceptorFactory>> {
     let mut res: Vec<InterceptorFactory> = vec![];
 
     if acl_config.enabled {
         let mut policy_enforcer = PolicyEnforcer::new();
+        policy_enforcer.namespace = namespace;
         match policy_enforcer.init(acl_config) {
             Ok(_) => {
                 tracing::debug!("Access control is enabled");
@@ -979,7 +981,7 @@ pub trait AclActionMethods {
         let policy_enforcer = self.policy_enforcer();
         let authn_ids = self.authn_ids();
         let zid = self.zid();
-        let mut decision = policy_enforcer.default_permission;
+        let mut decision = policy_enforcer.namespace_aware_default(key_expr);
         for subject in authn_ids {
             match policy_enforcer.policy_decision_point(subject.id, self.flow(), action, key_expr) {
                 Ok(Permission::Allow) => {

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -17,6 +17,16 @@
 //! This module is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
+//!
+//! # Namespace-aware ACL authorization
+//!
+//! Decision priority (highest to lowest):
+//! 1. **Explicit deny** — per-subject deny rule matches the key expression
+//! 2. **Explicit allow** — per-subject allow rule matches the key expression
+//! 3. **Namespace deny** — key expression is outside the configured namespace prefix
+//! 4. **Default permission** — the configured default (Allow or Deny)
+//!
+//! When no namespace is configured, step 3 is skipped — the default permission applies directly.
 use std::collections::{HashMap, HashSet};
 
 use ahash::RandomState;
@@ -28,6 +38,7 @@ use zenoh_config::{
 use zenoh_keyexpr::{
     keyexpr,
     keyexpr_tree::{IKeyExprTree, IKeyExprTreeMut, IKeyExprTreeNode, KeBoxTree},
+    OwnedNonWildKeyExpr,
 };
 use zenoh_result::ZResult;
 
@@ -261,6 +272,7 @@ impl FlowPolicy {
 pub struct PolicyEnforcer {
     pub(crate) acl_enabled: bool,
     pub(crate) default_permission: Permission,
+    pub(crate) namespace: Option<OwnedNonWildKeyExpr>,
     pub(crate) subject_store: SubjectStore,
     pub(crate) policy_map: PolicyMap,
     pub(crate) interface_enabled: InterfaceEnabled,
@@ -277,9 +289,24 @@ impl PolicyEnforcer {
         PolicyEnforcer {
             acl_enabled: true,
             default_permission: Permission::Deny,
+            namespace: None,
             subject_store: SubjectStore::default(),
             policy_map: PolicyMap::default(),
             interface_enabled: InterfaceEnabled::default(),
+        }
+    }
+
+    /// Check if a key expression is under the configured namespace.
+    /// Returns true if no namespace is set, or if the key matches/is under the namespace prefix.
+    /// `strip_nonwild_prefix` returns `None` when the key exactly equals the prefix (no
+    /// remaining suffix), so we also check for exact equality.
+    fn is_under_namespace(&self, key_expr: &keyexpr) -> bool {
+        match &self.namespace {
+            None => true,
+            Some(ns) => {
+                key_expr.as_str() == ns.as_str()
+                    || key_expr.strip_nonwild_prefix(ns).is_some()
+            }
         }
     }
 
@@ -308,7 +335,7 @@ impl PolicyEnforcer {
                     });
                     self.policy_map = PolicyMap::default();
                     self.subject_store = SubjectStore::default();
-                    if self.default_permission == Permission::Deny {
+                    if self.default_permission == Permission::Deny || self.namespace.is_some() {
                         self.interface_enabled = InterfaceEnabled {
                             ingress: true,
                             egress: true,
@@ -366,9 +393,23 @@ impl PolicyEnforcer {
                     }
                     self.policy_map = main_policy;
                     self.subject_store = policy_information.subject_map;
+                    if self.namespace.is_some() {
+                        self.interface_enabled = InterfaceEnabled {
+                            ingress: true,
+                            egress: true,
+                        };
+                    }
                 }
             } else {
                 bail!("All ACL rules/subjects/policies config lists must be provided");
+            }
+            if let Some(ns) = &self.namespace {
+                tracing::info!(
+                    "ACL auto-deny enabled for namespace '{}': keys outside '{}/{}' will be denied",
+                    ns.as_str(),
+                    ns.as_str(),
+                    "**"
+                );
             }
         }
         Ok(())
@@ -585,9 +626,26 @@ impl PolicyEnforcer {
         })
     }
 
-    /**
-     * Check each msg against the ACL ruleset for allow/deny
-     */
+    /// Return the default permission, but deny if the key is outside the namespace.
+    /// Priority: namespace deny > default permission.
+    pub(crate) fn namespace_aware_default(&self, key_expr: &keyexpr) -> Permission {
+        if !self.is_under_namespace(key_expr) {
+            return Permission::Deny;
+        }
+        self.default_permission
+    }
+
+    /// Check each msg against the ACL ruleset for allow/deny.
+    ///
+    /// ## Performance
+    ///
+    /// Called on every message. The namespace check (`namespace.is_none()` at the
+    /// fast-path branch and `is_under_namespace()` in `namespace_aware_default()`)
+    /// adds at most one `Option::is_none()` check and one `keyexpr::starts_with()`
+    /// comparison to the hot path. Both are O(1) operations on stack-local data —
+    /// no allocation, no lock, no syscall. When no namespace is configured, the
+    /// `is_none()` fast-path returns immediately without entering
+    /// `namespace_aware_default()`.
     pub fn policy_decision_point(
         &self,
         subject: usize,
@@ -597,10 +655,11 @@ impl PolicyEnforcer {
     ) -> ZResult<Permission> {
         let policy_map = &self.policy_map;
         if policy_map.is_empty() {
-            return Ok(self.default_permission);
+            return Ok(self.namespace_aware_default(key_expr));
         }
         match policy_map.get(&subject) {
             Some(single_policy) => {
+                // Priority: explicit deny > explicit allow > namespace deny > default permission
                 let deny_result = single_policy
                     .flow(flow)
                     .action(message)
@@ -610,9 +669,11 @@ impl PolicyEnforcer {
                 if deny_result {
                     return Ok(Permission::Deny);
                 }
-                if self.default_permission == Permission::Allow {
+                if self.default_permission == Permission::Allow && self.namespace.is_none() {
+                    // Fast path: default Allow, no namespace — no need to check allow tree
                     Ok(Permission::Allow)
                 } else {
+                    // Check explicit allow tree — explicit allow overrides namespace deny
                     let allow_result = single_policy
                         .flow(flow)
                         .action(message)
@@ -623,11 +684,311 @@ impl PolicyEnforcer {
                     if allow_result {
                         Ok(Permission::Allow)
                     } else {
-                        Ok(Permission::Deny)
+                        // No explicit allow — apply namespace deny then default permission
+                        Ok(self.namespace_aware_default(key_expr))
                     }
                 }
             }
-            None => Ok(self.default_permission),
+            None => Ok(self.namespace_aware_default(key_expr)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zenoh_config::{AclMessage, InterceptorFlow, Permission};
+    use zenoh_keyexpr::keyexpr;
+
+    /// Helper to create a PolicyEnforcer with namespace set.
+    fn enforcer_with_namespace(ns: &str, default_perm: Permission) -> PolicyEnforcer {
+        let mut enforcer = PolicyEnforcer::new();
+        enforcer.namespace = Some(
+            zenoh_keyexpr::OwnedNonWildKeyExpr::try_from(ns.to_string())
+                .expect("test namespace should be valid"),
+        );
+        enforcer.default_permission = default_perm;
+        enforcer
+    }
+
+    #[test]
+    fn namespace_denies_key_outside_namespace() {
+        // Router with namespace "tenant-a", default allow
+        // Key "tenant-b/data" is OUTSIDE namespace -> should be DENIED by auto-deny
+        let enforcer = enforcer_with_namespace("tenant-a", Permission::Allow);
+        let result = enforcer
+            .policy_decision_point(
+                0, // no matching subject in empty policy_map -> would normally return default_permission
+                InterceptorFlow::Ingress,
+                AclMessage::Put,
+                keyexpr::new("tenant-b/data").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Permission::Deny,
+            "key outside namespace should be denied"
+        );
+    }
+
+    #[test]
+    fn namespace_allows_key_inside_namespace() {
+        // Router with namespace "tenant-a", default allow
+        // Key "tenant-a/data" is INSIDE namespace -> should use default permission (Allow)
+        let enforcer = enforcer_with_namespace("tenant-a", Permission::Allow);
+        let result = enforcer
+            .policy_decision_point(
+                0,
+                InterceptorFlow::Ingress,
+                AclMessage::Put,
+                keyexpr::new("tenant-a/data").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Permission::Allow,
+            "key inside namespace should be allowed"
+        );
+    }
+
+    #[test]
+    fn namespace_allows_exact_namespace_key() {
+        // Key exactly matching the namespace (no trailing slash) should be allowed
+        let enforcer = enforcer_with_namespace("tenant-a", Permission::Allow);
+        let result = enforcer
+            .policy_decision_point(
+                0,
+                InterceptorFlow::Ingress,
+                AclMessage::Put,
+                keyexpr::new("tenant-a").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Permission::Allow,
+            "exact namespace key should be allowed"
+        );
+    }
+
+    #[test]
+    fn no_namespace_no_change() {
+        // No namespace configured -> default permission applies, no auto-deny
+        let mut enforcer = PolicyEnforcer::new();
+        enforcer.default_permission = Permission::Allow;
+        let result = enforcer
+            .policy_decision_point(
+                0,
+                InterceptorFlow::Ingress,
+                AclMessage::Put,
+                keyexpr::new("any/key/works").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Permission::Allow,
+            "no namespace should mean no auto-deny"
+        );
+    }
+
+    #[test]
+    fn namespace_applies_to_all_message_types() {
+        // Auto-deny should apply to all message types, not just Put
+        let enforcer = enforcer_with_namespace("ns1", Permission::Allow);
+        for msg_type in [
+            AclMessage::Put,
+            AclMessage::Delete,
+            AclMessage::Query,
+            AclMessage::Reply,
+            AclMessage::DeclareSubscriber,
+            AclMessage::DeclareQueryable,
+            AclMessage::LivelinessToken,
+            AclMessage::DeclareLivelinessSubscriber,
+            AclMessage::LivelinessQuery,
+        ] {
+            let result = enforcer
+                .policy_decision_point(
+                    0,
+                    InterceptorFlow::Ingress,
+                    msg_type,
+                    keyexpr::new("other/key").unwrap(),
+                )
+                .unwrap();
+            assert_eq!(
+                result,
+                Permission::Deny,
+                "namespace auto-deny should apply to {:?}",
+                msg_type
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_applies_to_both_flows() {
+        // Auto-deny should apply to both ingress and egress
+        let enforcer = enforcer_with_namespace("ns1", Permission::Allow);
+        for flow in [InterceptorFlow::Ingress, InterceptorFlow::Egress] {
+            let result = enforcer
+                .policy_decision_point(
+                    0,
+                    flow,
+                    AclMessage::Put,
+                    keyexpr::new("other/key").unwrap(),
+                )
+                .unwrap();
+            assert_eq!(
+                result,
+                Permission::Deny,
+                "namespace auto-deny should apply to {:?}",
+                flow
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_allow_overrides_namespace_deny() {
+        // Set up: namespace "ns1", default deny, explicit allow rule for "other/data"
+        // Key "other/data" is OUTSIDE namespace but has explicit allow -> should ALLOW
+        // Priority: explicit deny > explicit allow > namespace deny > default permission
+        let mut enforcer = PolicyEnforcer::new();
+        enforcer.namespace = Some(
+            zenoh_keyexpr::OwnedNonWildKeyExpr::try_from("ns1".to_string())
+                .expect("test namespace should be valid"),
+        );
+        enforcer.acl_enabled = true;
+        enforcer.default_permission = Permission::Deny;
+
+        // Build a minimal ACL config with an explicit allow for "other/data"
+        let acl_config = zenoh_config::AclConfig {
+            enabled: true,
+            default_permission: Permission::Deny,
+            rules: Some(vec![AclConfigRule {
+                id: "allow-cross-ns".to_string(),
+                permission: Permission::Allow,
+                flows: Some(
+                    vec![InterceptorFlow::Ingress, InterceptorFlow::Egress]
+                        .try_into()
+                        .unwrap(),
+                ),
+                messages: vec![AclMessage::Put].try_into().unwrap(),
+                key_exprs: vec!["other/data".try_into().unwrap()].try_into().unwrap(),
+            }]),
+            subjects: Some(vec![AclConfigSubjects {
+                id: "all".to_string(),
+                interfaces: None,
+                cert_common_names: None,
+                usernames: None,
+                link_protocols: None,
+                zids: None,
+            }]),
+            policies: Some(vec![AclConfigPolicyEntry {
+                id: None,
+                rules: vec!["allow-cross-ns".to_string()],
+                subjects: vec!["all".to_string()],
+            }]),
+        };
+
+        // Re-init with ACL config (preserving namespace)
+        enforcer.init(&acl_config).unwrap();
+
+        // Find the subject ID for "all"
+        let subject_query = SubjectQuery {
+            interface: None,
+            cert_common_name: None,
+            username: None,
+            link_protocol: None,
+            zid: None,
+        };
+        let subject_id = enforcer
+            .subject_store
+            .query(&subject_query)
+            .next()
+            .expect("should have a subject")
+            .id;
+
+        let result = enforcer
+            .policy_decision_point(
+                subject_id,
+                InterceptorFlow::Ingress,
+                AclMessage::Put,
+                keyexpr::new("other/data").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Permission::Allow,
+            "explicit allow should override namespace auto-deny"
+        );
+    }
+
+    #[test]
+    fn explicit_deny_still_wins_over_namespace() {
+        // Explicit deny should still take precedence (existing behavior preserved)
+        let mut enforcer = PolicyEnforcer::new();
+        enforcer.namespace = Some(
+            zenoh_keyexpr::OwnedNonWildKeyExpr::try_from("ns1".to_string())
+                .expect("test namespace should be valid"),
+        );
+        enforcer.acl_enabled = true;
+        enforcer.default_permission = Permission::Allow;
+
+        let acl_config = zenoh_config::AclConfig {
+            enabled: true,
+            default_permission: Permission::Allow,
+            rules: Some(vec![AclConfigRule {
+                id: "deny-inside".to_string(),
+                permission: Permission::Deny,
+                flows: Some(
+                    vec![InterceptorFlow::Ingress, InterceptorFlow::Egress]
+                        .try_into()
+                        .unwrap(),
+                ),
+                messages: vec![AclMessage::Put].try_into().unwrap(),
+                key_exprs: vec!["ns1/secret".try_into().unwrap()].try_into().unwrap(),
+            }]),
+            subjects: Some(vec![AclConfigSubjects {
+                id: "all".to_string(),
+                interfaces: None,
+                cert_common_names: None,
+                usernames: None,
+                link_protocols: None,
+                zids: None,
+            }]),
+            policies: Some(vec![AclConfigPolicyEntry {
+                id: None,
+                rules: vec!["deny-inside".to_string()],
+                subjects: vec!["all".to_string()],
+            }]),
+        };
+
+        enforcer.init(&acl_config).unwrap();
+
+        let subject_query = SubjectQuery {
+            interface: None,
+            cert_common_name: None,
+            username: None,
+            link_protocol: None,
+            zid: None,
+        };
+        let subject_id = enforcer
+            .subject_store
+            .query(&subject_query)
+            .next()
+            .expect("should have a subject")
+            .id;
+
+        // "ns1/secret" is inside namespace but has explicit deny -> DENY
+        let result = enforcer
+            .policy_decision_point(
+                subject_id,
+                InterceptorFlow::Ingress,
+                AclMessage::Put,
+                keyexpr::new("ns1/secret").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Permission::Deny,
+            "explicit deny should still take precedence"
+        );
     }
 }

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -139,7 +139,10 @@ pub(crate) fn interceptor_factories(config: &Config) -> ZResult<Vec<InterceptorF
         }
     }
     res.extend(downsampling_interceptor_factories(config.downsampling())?);
-    res.extend(acl_interceptor_factories(config.access_control())?);
+    res.extend(acl_interceptor_factories(
+        config.access_control(),
+        config.namespace.clone(),
+    )?);
     res.extend(qos_overwrite_interceptor_factories(config.qos().network())?);
     res.extend(low_pass_interceptor_factories(config.low_pass_filter())?);
     Ok(res)

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -78,6 +78,14 @@ async fn test_acl_liveliness() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_acl_namespace_auto_deny() {
+    zenoh::init_log_from_env_or("error");
+    test_namespace_auto_deny_blocks_outside(27460).await;
+    test_namespace_no_namespace_no_change(27460).await;
+    test_namespace_cross_namespace_blocked(27461).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_interface_names() {
     zenoh::init_log_from_env_or("error");
 
@@ -2065,4 +2073,185 @@ async fn test_pub_sub_network_interface(port: u16) {
     }
     close_sessions(sub_session, pub_session).await;
     close_router_session(session).await;
+}
+
+async fn test_namespace_auto_deny_blocks_outside(port: u16) {
+    println!("test_namespace_auto_deny_blocks_outside");
+    // Router with namespace "ns1" and ACL default allow
+    // Client puts to "other/data" (outside namespace) -> should be blocked
+    let mut config_router = get_basic_router_config(port).await;
+    config_router.namespace = Some(
+        zenoh_keyexpr::OwnedNonWildKeyExpr::try_from("ns1".to_string())
+            .expect("namespace should be valid"),
+    );
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+                "enabled": true,
+                "default_permission": "allow",
+                "rules": [],
+                "subjects": [],
+                "policies": []
+            }"#,
+        )
+        .unwrap();
+
+    println!("Opening router session");
+    let session = ztimeout!(zenoh::open(config_router)).unwrap();
+    let (sub_session, pub_session) = get_client_sessions(port).await;
+    {
+        // Put to a key OUTSIDE the namespace
+        let publisher = pub_session.declare_publisher("other/data").await.unwrap();
+        let received_value = Arc::new(Mutex::new(String::new()));
+
+        let temp_recv_value = received_value.clone();
+        let subscriber = sub_session
+            .declare_subscriber("other/data")
+            .callback(move |sample| {
+                if sample.kind() == SampleKind::Put {
+                    let mut temp_value = zlock!(temp_recv_value);
+                    *temp_value = sample.payload().try_to_string().unwrap().into_owned();
+                }
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(SLEEP).await;
+        publisher.put(VALUE).await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+        // Should NOT be received -- blocked by namespace auto-deny
+        assert_ne!(*zlock!(received_value), VALUE);
+        ztimeout!(subscriber.undeclare()).unwrap();
+    }
+    close_sessions(sub_session, pub_session).await;
+    close_router_session(session).await;
+}
+
+async fn test_namespace_no_namespace_no_change(port: u16) {
+    println!("test_namespace_no_namespace_no_change");
+    // Router with NO namespace, ACL default allow
+    // Should behave exactly like normal ACL (allow everything)
+    let mut config_router = get_basic_router_config(port).await;
+    // No namespace set
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+                "enabled": true,
+                "default_permission": "allow",
+                "rules": [],
+                "subjects": [],
+                "policies": []
+            }"#,
+        )
+        .unwrap();
+
+    println!("Opening router session");
+    let session = ztimeout!(zenoh::open(config_router)).unwrap();
+    let (sub_session, pub_session) = get_client_sessions(port).await;
+    {
+        let publisher = pub_session.declare_publisher(KEY_EXPR).await.unwrap();
+        let received_value = Arc::new(Mutex::new(String::new()));
+
+        let temp_recv_value = received_value.clone();
+        let subscriber = sub_session
+            .declare_subscriber(KEY_EXPR)
+            .callback(move |sample| {
+                if sample.kind() == SampleKind::Put {
+                    let mut temp_value = zlock!(temp_recv_value);
+                    *temp_value = sample.payload().try_to_string().unwrap().into_owned();
+                }
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(SLEEP).await;
+        publisher.put(VALUE).await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+        // SHOULD be received -- no namespace, no auto-deny
+        assert_eq!(*zlock!(received_value), VALUE);
+        ztimeout!(subscriber.undeclare()).unwrap();
+    }
+    close_sessions(sub_session, pub_session).await;
+    close_router_session(session).await;
+}
+
+async fn test_namespace_cross_namespace_blocked(port: u16) {
+    println!("test_namespace_cross_namespace_blocked");
+    // Two clients with different namespaces through a router with namespace "ns1"
+    // Client A (namespace "ns1") publishes to "data" -> becomes "ns1/data" on the wire
+    // Client B (namespace "ns2") subscribes to "data" -> expects "ns2/data" on the wire
+    // Router with namespace "ns1" blocks "ns2/**" traffic
+    let mut config_router = get_basic_router_config(port).await;
+    config_router.namespace = Some(
+        zenoh_keyexpr::OwnedNonWildKeyExpr::try_from("ns1".to_string())
+            .expect("namespace should be valid"),
+    );
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+                "enabled": true,
+                "default_permission": "allow",
+                "rules": [],
+                "subjects": [],
+                "policies": []
+            }"#,
+        )
+        .unwrap();
+
+    let router = ztimeout!(zenoh::open(config_router)).unwrap();
+
+    // Client A: namespace "ns1" (matches router)
+    let mut config_a = get_basic_client_config(port).await;
+    config_a.namespace = Some(
+        zenoh_keyexpr::OwnedNonWildKeyExpr::try_from("ns1".to_string())
+            .expect("namespace should be valid"),
+    );
+
+    // Client B: namespace "ns2" (different from router)
+    let mut config_b = get_basic_client_config(port).await;
+    config_b.namespace = Some(
+        zenoh_keyexpr::OwnedNonWildKeyExpr::try_from("ns2".to_string())
+            .expect("namespace should be valid"),
+    );
+
+    let session_a = ztimeout!(zenoh::open(config_a)).unwrap();
+    let session_b = ztimeout!(zenoh::open(config_b)).unwrap();
+
+    {
+        // Client B subscribes to "data" (which becomes "ns2/data" on the wire)
+        let received_value = Arc::new(Mutex::new(String::new()));
+        let temp_recv_value = received_value.clone();
+        let subscriber = session_b
+            .declare_subscriber("data")
+            .callback(move |sample| {
+                if sample.kind() == SampleKind::Put {
+                    let mut temp_value = zlock!(temp_recv_value);
+                    *temp_value = sample.payload().try_to_string().unwrap().into_owned();
+                }
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(SLEEP).await;
+
+        // Client A publishes to "data" (which becomes "ns1/data" on the wire)
+        let publisher = session_a.declare_publisher("data").await.unwrap();
+        publisher.put(VALUE).await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+
+        // Client B should NOT receive -- cross-namespace traffic is blocked
+        assert_ne!(
+            *zlock!(received_value),
+            VALUE,
+            "cross-namespace message should be blocked"
+        );
+        ztimeout!(subscriber.undeclare()).unwrap();
+    }
+
+    ztimeout!(session_a.close()).unwrap();
+    ztimeout!(session_b.close()).unwrap();
+    close_router_session(router).await;
 }


### PR DESCRIPTION
## Summary
- Extract ACL namespace auto-deny changes from `zenoh/namespace-isolation` branch as a clean PR
- Add 4-tier ACL decision chain: explicit deny > explicit allow > namespace deny > default permission
- When a namespace is configured, keys outside the namespace prefix are automatically denied
- Explicit ACL allow rules can override namespace auto-deny
- O(1) hot-path overhead via `keyexpr::strip_nonwild_prefix` — no allocation, no lock, no syscall

## Changes
- `zenoh/src/net/routing/interceptor/authorization.rs` — `namespace` field on PolicyEnforcer, `is_under_namespace()`, `namespace_aware_default()`, modified `policy_decision_point()` with 4-tier priority, 8 unit tests
- `zenoh/src/net/routing/interceptor/access_control.rs` — namespace parameter plumbing, use `namespace_aware_default()` for initial decision
- `zenoh/src/net/routing/interceptor/mod.rs` — pass `config.namespace` to ACL factory
- `zenoh/tests/acl.rs` — 3 integration tests (auto-deny blocks outside, no-namespace passthrough, cross-namespace blocked)

## Testing
- 8 unit tests covering all decision chain paths:
  - `namespace_denies_key_outside_namespace`
  - `namespace_allows_key_inside_namespace`
  - `namespace_allows_exact_namespace_key`
  - `no_namespace_no_change`
  - `namespace_applies_to_all_message_types`
  - `namespace_applies_to_both_flows`
  - `explicit_allow_overrides_namespace_deny`
  - `explicit_deny_still_wins_over_namespace`
- 3 integration tests (behind `unstable` feature flag)
- All existing ACL tests pass, no regressions
- `cargo clippy`, `cargo fmt --check` clean

## Dependencies
- Based on `fix/124-connection-limits` (PR #127)

Closes #125