### PR TITLE
feat: extract ServiceError, DeadlineContext, and discovery to zenoh-rpc

### DIFF
--- a/zenoh-rpc/src/deadline.rs
+++ b/zenoh-rpc/src/deadline.rs
@@ -1,0 +1,167 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use zenoh_ext::z_deserialize;
+
+/// Attachment key for the absolute deadline (millis since UNIX epoch).
+pub const DEADLINE_ATTACHMENT_KEY: &str = "rpc:deadline_ms";
+
+/// Server-side helper that computes remaining budget from the attached deadline.
+///
+/// A `DeadlineContext` is created from the absolute deadline (milliseconds since
+/// the UNIX epoch) that the client attaches to its query. The server can then
+/// check how much time remains before the deadline expires.
+pub struct DeadlineContext {
+    deadline_ms: u64,
+}
+
+impl DeadlineContext {
+    /// Create from the deadline attachment value (millis since UNIX epoch).
+    pub fn from_millis(deadline_ms: u64) -> Self {
+        Self { deadline_ms }
+    }
+
+    /// Extract from a zenoh Query's attachment, if present.
+    ///
+    /// The attachment is expected to be a serialized `HashMap<String, String>`
+    /// containing the key [`DEADLINE_ATTACHMENT_KEY`] with the deadline value
+    /// as a decimal string of milliseconds since the UNIX epoch.
+    ///
+    /// Returns `None` if the attachment is missing, cannot be deserialized,
+    /// or does not contain the deadline key.
+    pub fn from_query(query: &zenoh::query::Query) -> Option<Self> {
+        let attachment = query.attachment()?;
+        let map: HashMap<String, String> = z_deserialize(attachment).ok()?;
+        let deadline_str = map.get(DEADLINE_ATTACHMENT_KEY)?;
+        let deadline_ms: u64 = deadline_str.parse().ok()?;
+        Some(Self { deadline_ms })
+    }
+
+    /// Returns the remaining time budget. Returns `Duration::ZERO` if expired.
+    pub fn remaining(&self) -> Duration {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_millis() as u64;
+        if self.deadline_ms > now_ms {
+            Duration::from_millis(self.deadline_ms - now_ms)
+        } else {
+            Duration::ZERO
+        }
+    }
+
+    /// Returns `true` if the deadline has passed.
+    pub fn is_expired(&self) -> bool {
+        self.remaining() == Duration::ZERO
+    }
+
+    /// Returns the absolute deadline as millis since UNIX epoch.
+    pub fn deadline_ms(&self) -> u64 {
+        self.deadline_ms
+    }
+}
+
+/// Compute the deadline attachment key-value pair from a timeout duration.
+///
+/// The returned pair can be inserted into an attachment map (`HashMap<String, String>`)
+/// and serialized via [`zenoh_ext::z_serialize`] before attaching to a query.
+///
+/// The deadline is computed as `now + timeout`, expressed as milliseconds since
+/// the UNIX epoch.
+pub fn deadline_attachment(timeout: Duration) -> (String, String) {
+    let deadline_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64
+        + timeout.as_millis() as u64;
+    (DEADLINE_ATTACHMENT_KEY.to_string(), deadline_ms.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_millis_stores_deadline() {
+        let ctx = DeadlineContext::from_millis(1_000_000);
+        assert_eq!(ctx.deadline_ms(), 1_000_000);
+    }
+
+    #[test]
+    fn future_deadline_is_not_expired() {
+        let future_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            + 60_000; // 60 seconds from now
+        let ctx = DeadlineContext::from_millis(future_ms);
+        assert!(!ctx.is_expired());
+        assert!(ctx.remaining() > Duration::ZERO);
+        assert!(ctx.remaining() <= Duration::from_secs(60));
+    }
+
+    #[test]
+    fn past_deadline_is_expired() {
+        let ctx = DeadlineContext::from_millis(0); // epoch = always in the past
+        assert!(ctx.is_expired());
+        assert_eq!(ctx.remaining(), Duration::ZERO);
+    }
+
+    #[test]
+    fn deadline_attachment_produces_valid_pair() {
+        let timeout = Duration::from_secs(5);
+        let (key, value) = deadline_attachment(timeout);
+        assert_eq!(key, DEADLINE_ATTACHMENT_KEY);
+
+        let deadline_ms: u64 = value.parse().expect("value should be a u64 string");
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        // The deadline should be roughly now + 5s (within 1s tolerance)
+        assert!(deadline_ms >= now_ms + 4_000);
+        assert!(deadline_ms <= now_ms + 6_000);
+    }
+
+    #[test]
+    fn remaining_decreases_over_time() {
+        let future_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            + 10_000;
+        let ctx = DeadlineContext::from_millis(future_ms);
+        let r1 = ctx.remaining();
+        // remaining should be <= 10s
+        assert!(r1 <= Duration::from_secs(10));
+        assert!(r1 > Duration::from_secs(9));
+    }
+
+    #[test]
+    fn zero_timeout_produces_near_now_deadline() {
+        let (_, value) = deadline_attachment(Duration::ZERO);
+        let deadline_ms: u64 = value.parse().unwrap();
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        // Should be within 100ms of now
+        assert!(deadline_ms <= now_ms + 100);
+    }
+}

--- a/zenoh-rpc/src/discovery.rs
+++ b/zenoh-rpc/src/discovery.rs
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+/// FNV-1a hash for producing compact, deterministic key expression hashes.
+pub fn fnv1a_hash(data: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for &byte in data {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+/// Build the liveliness key for a specific service instance.
+///
+/// Format: `@rpc/{key_expr_hash:x}/{zenoh_id}`
+pub fn service_liveliness_token_key(key_expr: &str, zenoh_id: &str) -> String {
+    let hash = fnv1a_hash(key_expr.as_bytes());
+    format!("@rpc/{hash:x}/{zenoh_id}")
+}
+
+/// Build the liveliness query prefix to discover all instances of a service.
+///
+/// Format: `@rpc/{key_expr_hash:x}/**`
+pub fn service_liveliness_prefix(key_expr: &str) -> String {
+    let hash = fnv1a_hash(key_expr.as_bytes());
+    format!("@rpc/{hash:x}/**")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv1a_hash_is_deterministic() {
+        let a = fnv1a_hash(b"test/service/key");
+        let b = fnv1a_hash(b"test/service/key");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn fnv1a_hash_differs_for_different_inputs() {
+        let a = fnv1a_hash(b"service/a");
+        let b = fnv1a_hash(b"service/b");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn service_liveliness_token_key_format() {
+        let key = service_liveliness_token_key("my/service", "abc123");
+        assert!(key.starts_with("@rpc/"));
+        assert!(key.ends_with("/abc123"));
+        // Should contain the hex hash between the prefix and zenoh_id
+        let parts: Vec<&str> = key.split('/').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], "@rpc");
+        assert_eq!(parts[2], "abc123");
+    }
+
+    #[test]
+    fn service_liveliness_prefix_format() {
+        let prefix = service_liveliness_prefix("my/service");
+        assert!(prefix.starts_with("@rpc/"));
+        assert!(prefix.ends_with("/**"));
+    }
+
+    #[test]
+    fn token_key_and_prefix_share_hash() {
+        let key = service_liveliness_token_key("svc/foo", "zid1");
+        let prefix = service_liveliness_prefix("svc/foo");
+        // The hash portion should match
+        let key_hash = key.split('/').nth(1).unwrap();
+        let prefix_hash = prefix.split('/').nth(1).unwrap();
+        assert_eq!(key_hash, prefix_hash);
+    }
+}

--- a/zenoh-rpc/src/error.rs
+++ b/zenoh-rpc/src/error.rs
@@ -1,0 +1,406 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::fmt;
+
+use zenoh::bytes::ZBytes;
+
+use zenoh_ext::{
+    z_deserialize, z_serialize, Deserialize, Serialize, ZDeserializeError, ZDeserializer,
+    ZSerializer,
+};
+
+/// Status codes for fast-path error detection via attachments.
+///
+/// Each variant maps to a single byte discriminant, enabling efficient
+/// status checks without deserializing the full error payload.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusCode {
+    /// The request completed successfully.
+    Ok = 0,
+    /// The request payload was malformed or invalid.
+    InvalidRequest = 1,
+    /// The requested resource was not found.
+    NotFound = 2,
+    /// The request exceeded its time budget.
+    DeadlineExceeded = 3,
+    /// An internal service error occurred.
+    Internal = 4,
+    /// The requested RPC method does not exist.
+    MethodNotFound = 5,
+    /// An application-defined error with a custom code.
+    Application = 6,
+}
+
+impl StatusCode {
+    /// Try to convert a raw `u8` discriminant into a [`StatusCode`].
+    fn from_u8(v: u8) -> Result<Self, ZDeserializeError> {
+        match v {
+            0 => Ok(Self::Ok),
+            1 => Ok(Self::InvalidRequest),
+            2 => Ok(Self::NotFound),
+            3 => Ok(Self::DeadlineExceeded),
+            4 => Ok(Self::Internal),
+            5 => Ok(Self::MethodNotFound),
+            6 => Ok(Self::Application),
+            _ => Err(ZDeserializeError),
+        }
+    }
+}
+
+impl Serialize for StatusCode {
+    fn serialize(&self, serializer: &mut ZSerializer) {
+        (*self as u8).serialize(serializer);
+    }
+}
+
+impl Deserialize for StatusCode {
+    fn deserialize(deserializer: &mut ZDeserializer) -> Result<Self, ZDeserializeError> {
+        Self::from_u8(u8::deserialize(deserializer)?)
+    }
+}
+
+/// Structured error type for the RPC layer.
+///
+/// Each variant carries the data needed to diagnose the failure.
+/// The wire format is: `status_code: u8` followed by variant-specific fields,
+/// using the same serialization conventions as the rest of zenoh-ext.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceError {
+    /// The request payload was malformed or failed validation.
+    InvalidRequest { message: String },
+    /// The requested resource (key, entity, etc.) was not found.
+    NotFound { message: String },
+    /// The request exceeded its time budget.
+    DeadlineExceeded { budget_ms: u64 },
+    /// An unexpected internal error.
+    Internal { message: String },
+    /// The named RPC method does not exist on this service.
+    MethodNotFound { method: String },
+    /// An application-defined error carrying a custom numeric code.
+    Application { code: u32, message: String },
+}
+
+impl ServiceError {
+    /// Returns the [`StatusCode`] corresponding to this error variant.
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            Self::InvalidRequest { .. } => StatusCode::InvalidRequest,
+            Self::NotFound { .. } => StatusCode::NotFound,
+            Self::DeadlineExceeded { .. } => StatusCode::DeadlineExceeded,
+            Self::Internal { .. } => StatusCode::Internal,
+            Self::MethodNotFound { .. } => StatusCode::MethodNotFound,
+            Self::Application { .. } => StatusCode::Application,
+        }
+    }
+}
+
+impl fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest { message } => write!(f, "invalid request: {message}"),
+            Self::NotFound { message } => write!(f, "not found: {message}"),
+            Self::DeadlineExceeded { budget_ms } => {
+                write!(f, "deadline exceeded: budget was {budget_ms}ms")
+            }
+            Self::Internal { message } => write!(f, "internal error: {message}"),
+            Self::MethodNotFound { method } => write!(f, "method not found: {method}"),
+            Self::Application { code, message } => {
+                write!(f, "application error ({code}): {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ServiceError {}
+
+impl Serialize for ServiceError {
+    fn serialize(&self, serializer: &mut ZSerializer) {
+        // Discriminant byte
+        self.status_code().serialize(serializer);
+        // Variant-specific fields
+        match self {
+            Self::InvalidRequest { message } => serializer.serialize(message),
+            Self::NotFound { message } => serializer.serialize(message),
+            Self::DeadlineExceeded { budget_ms } => serializer.serialize(*budget_ms),
+            Self::Internal { message } => serializer.serialize(message),
+            Self::MethodNotFound { method } => serializer.serialize(method),
+            Self::Application { code, message } => {
+                serializer.serialize(*code);
+                serializer.serialize(message);
+            }
+        }
+    }
+}
+
+impl Deserialize for ServiceError {
+    fn deserialize(deserializer: &mut ZDeserializer) -> Result<Self, ZDeserializeError> {
+        let code = StatusCode::deserialize(deserializer)?;
+        match code {
+            StatusCode::Ok => Err(ZDeserializeError), // Ok is not an error variant
+            StatusCode::InvalidRequest => Ok(Self::InvalidRequest {
+                message: deserializer.deserialize()?,
+            }),
+            StatusCode::NotFound => Ok(Self::NotFound {
+                message: deserializer.deserialize()?,
+            }),
+            StatusCode::DeadlineExceeded => Ok(Self::DeadlineExceeded {
+                budget_ms: deserializer.deserialize()?,
+            }),
+            StatusCode::Internal => Ok(Self::Internal {
+                message: deserializer.deserialize()?,
+            }),
+            StatusCode::MethodNotFound => Ok(Self::MethodNotFound {
+                method: deserializer.deserialize()?,
+            }),
+            StatusCode::Application => Ok(Self::Application {
+                code: deserializer.deserialize()?,
+                message: deserializer.deserialize()?,
+            }),
+        }
+    }
+}
+
+impl From<ServiceError> for ZBytes {
+    fn from(err: ServiceError) -> Self {
+        z_serialize(&err)
+    }
+}
+
+impl TryFrom<ZBytes> for ServiceError {
+    type Error = ZDeserializeError;
+
+    fn try_from(zbytes: ZBytes) -> Result<Self, Self::Error> {
+        z_deserialize(&zbytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: serialize then deserialize a ServiceError, assert round-trip equality.
+    fn round_trip(err: &ServiceError) -> ServiceError {
+        let zbytes = z_serialize(err);
+        z_deserialize::<ServiceError>(&zbytes).expect("round-trip deserialization failed")
+    }
+
+    // -- Round-trip tests for each variant --
+
+    #[test]
+    fn round_trip_invalid_request() {
+        let err = ServiceError::InvalidRequest {
+            message: "missing field 'id'".to_string(),
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn round_trip_not_found() {
+        let err = ServiceError::NotFound {
+            message: "device 42 not found".to_string(),
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn round_trip_deadline_exceeded() {
+        let err = ServiceError::DeadlineExceeded { budget_ms: 5000 };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn round_trip_internal() {
+        let err = ServiceError::Internal {
+            message: "database connection lost".to_string(),
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn round_trip_method_not_found() {
+        let err = ServiceError::MethodNotFound {
+            method: "getDeviceConfig".to_string(),
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn round_trip_application() {
+        let err = ServiceError::Application {
+            code: 1001,
+            message: "quota exceeded".to_string(),
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    // -- status_code() tests --
+
+    #[test]
+    fn status_code_mapping() {
+        assert_eq!(
+            ServiceError::InvalidRequest {
+                message: String::new()
+            }
+            .status_code(),
+            StatusCode::InvalidRequest
+        );
+        assert_eq!(
+            ServiceError::NotFound {
+                message: String::new()
+            }
+            .status_code(),
+            StatusCode::NotFound
+        );
+        assert_eq!(
+            ServiceError::DeadlineExceeded { budget_ms: 0 }.status_code(),
+            StatusCode::DeadlineExceeded
+        );
+        assert_eq!(
+            ServiceError::Internal {
+                message: String::new()
+            }
+            .status_code(),
+            StatusCode::Internal
+        );
+        assert_eq!(
+            ServiceError::MethodNotFound {
+                method: String::new()
+            }
+            .status_code(),
+            StatusCode::MethodNotFound
+        );
+        assert_eq!(
+            ServiceError::Application {
+                code: 0,
+                message: String::new()
+            }
+            .status_code(),
+            StatusCode::Application
+        );
+    }
+
+    // -- Display tests --
+
+    #[test]
+    fn display_formatting() {
+        assert_eq!(
+            ServiceError::InvalidRequest {
+                message: "bad input".to_string()
+            }
+            .to_string(),
+            "invalid request: bad input"
+        );
+        assert_eq!(
+            ServiceError::NotFound {
+                message: "key xyz".to_string()
+            }
+            .to_string(),
+            "not found: key xyz"
+        );
+        assert_eq!(
+            ServiceError::DeadlineExceeded { budget_ms: 3000 }.to_string(),
+            "deadline exceeded: budget was 3000ms"
+        );
+        assert_eq!(
+            ServiceError::Internal {
+                message: "crash".to_string()
+            }
+            .to_string(),
+            "internal error: crash"
+        );
+        assert_eq!(
+            ServiceError::MethodNotFound {
+                method: "foo".to_string()
+            }
+            .to_string(),
+            "method not found: foo"
+        );
+        assert_eq!(
+            ServiceError::Application {
+                code: 42,
+                message: "nope".to_string()
+            }
+            .to_string(),
+            "application error (42): nope"
+        );
+    }
+
+    // -- Ergonomic conversion tests --
+
+    #[test]
+    fn zbytes_from_service_error() {
+        let err = ServiceError::Internal {
+            message: "oops".to_string(),
+        };
+        let zbytes: ZBytes = err.clone().into();
+        let recovered = ServiceError::try_from(zbytes).expect("conversion failed");
+        assert_eq!(recovered, err);
+    }
+
+    // -- Edge cases --
+
+    #[test]
+    fn deserialize_ok_status_code_is_error() {
+        // Manually serialize a StatusCode::Ok byte — this should fail to deserialize as ServiceError
+        let zbytes = z_serialize(&(StatusCode::Ok as u8));
+        assert!(z_deserialize::<ServiceError>(&zbytes).is_err());
+    }
+
+    #[test]
+    fn deserialize_invalid_discriminant_is_error() {
+        let zbytes = z_serialize(&255u8);
+        assert!(z_deserialize::<ServiceError>(&zbytes).is_err());
+    }
+
+    #[test]
+    fn round_trip_empty_strings() {
+        let err = ServiceError::InvalidRequest {
+            message: String::new(),
+        };
+        assert_eq!(round_trip(&err), err);
+
+        let err = ServiceError::Application {
+            code: 0,
+            message: String::new(),
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn round_trip_large_budget() {
+        let err = ServiceError::DeadlineExceeded {
+            budget_ms: u64::MAX,
+        };
+        assert_eq!(round_trip(&err), err);
+    }
+
+    #[test]
+    fn status_code_round_trip() {
+        for code in [
+            StatusCode::Ok,
+            StatusCode::InvalidRequest,
+            StatusCode::NotFound,
+            StatusCode::DeadlineExceeded,
+            StatusCode::Internal,
+            StatusCode::MethodNotFound,
+            StatusCode::Application,
+        ] {
+            let zbytes = z_serialize(&code);
+            let recovered = z_deserialize::<StatusCode>(&zbytes).expect("status code round-trip");
+            assert_eq!(recovered, code);
+        }
+    }
+}

--- a/zenoh-rpc/src/lib.rs
+++ b/zenoh-rpc/src/lib.rs
@@ -31,3 +31,11 @@
 //!
 //! - `default`: Core RPC functionality
 //! - `unstable`: Gated experimental APIs
+
+mod deadline;
+mod discovery;
+mod error;
+
+pub use deadline::{deadline_attachment, DeadlineContext, DEADLINE_ATTACHMENT_KEY};
+pub use discovery::{fnv1a_hash, service_liveliness_prefix, service_liveliness_token_key};
+pub use error::{ServiceError, StatusCode};


### PR DESCRIPTION
## Summary
- Extract `ServiceError`/`StatusCode` from `zenoh-ext/src/rpc/error.rs` to `zenoh-rpc/src/error.rs` (#106)
- Extract `DeadlineContext`/`deadline_attachment` from `zenoh-ext/src/rpc/deadline.rs` to `zenoh-rpc/src/deadline.rs` (#107)
- Extract `fnv1a_hash` and liveliness key helpers from `zenoh-ext/src/rpc/discovery.rs` to `zenoh-rpc/src/discovery.rs` (#108)

## Changes
- `zenoh-rpc/src/error.rs` — ServiceError (6 variants), StatusCode, Serialize/Deserialize impls, ZBytes conversions, 15 unit tests
- `zenoh-rpc/src/deadline.rs` — DeadlineContext, deadline_attachment helper, DEADLINE_ATTACHMENT_KEY constant, 6 new unit tests
- `zenoh-rpc/src/discovery.rs` — FNV-1a hash, liveliness token/prefix builders (now `pub` vs `pub(super)`), 5 unit tests
- `zenoh-rpc/src/lib.rs` — module wiring and public re-exports

## Note on temporary duplication
zenoh-ext retains its copies of these modules because `server.rs`/`client.rs` still import from `crate::rpc::*`. Adding `zenoh-ext → zenoh-rpc` would create a circular dependency (zenoh-rpc already depends on zenoh-ext for serialization traits). The duplication is resolved when #109/#110 extract ServiceServer/ServiceClient to zenoh-rpc.

## Testing
- 25 tests pass in zenoh-rpc (error: 15, deadline: 6, discovery: 5, minus 1 shared)
- zenoh-ext tests pass with no regressions (21 passed, 4 ignored)
- clippy clean

Closes #106
Closes #107
Closes #108

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->