### PR TITLE
feat: extract ServiceServer and ServiceClient to zenoh-rpc

### DIFF
--- a/zenoh-rpc/src/client.rs
+++ b/zenoh-rpc/src/client.rs
@@ -1,0 +1,201 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use zenoh::bytes::ZBytes;
+use zenoh::key_expr::KeyExpr;
+use zenoh::session::Session;
+
+use crate::deadline::deadline_attachment;
+use crate::discovery::service_liveliness_prefix;
+use crate::error::{ServiceError, StatusCode};
+use crate::server::{METHOD_ATTACHMENT_KEY, STATUS_ATTACHMENT_KEY};
+use zenoh_ext::{z_deserialize, z_serialize};
+
+/// An RPC client that sends typed method calls to a remote [`ServiceServer`](crate::ServiceServer).
+///
+/// The client serializes requests, attaches method name and deadline metadata,
+/// sends them via `session.get()`, and deserializes the response. Error replies
+/// from the server are deserialized into [`ServiceError`] variants.
+///
+/// # Example
+///
+/// ```ignore
+/// use std::time::Duration;
+/// use zenoh_rpc::ServiceClient;
+///
+/// let client = ServiceClient::new(&session, "my/service", Duration::from_secs(5))?;
+/// let response: String = client.call("get_config", &"key".to_string(), None).await?;
+/// ```
+pub struct ServiceClient {
+    session: Session,
+    key_expr: KeyExpr<'static>,
+    default_timeout: Duration,
+}
+
+impl ServiceClient {
+    /// Create a new `ServiceClient`.
+    ///
+    /// # Arguments
+    ///
+    /// * `session` — The zenoh session used to send queries.
+    /// * `key_expr` — The key expression of the remote service.
+    /// * `default_timeout` — Default timeout for calls when none is specified.
+    pub fn new(
+        session: &Session,
+        key_expr: &str,
+        default_timeout: Duration,
+    ) -> zenoh::Result<Self> {
+        let key_expr: KeyExpr<'static> = KeyExpr::try_from(key_expr.to_string())
+            .map_err(|e| -> zenoh::Error { format!("invalid key expression: {e}").into() })?;
+        Ok(Self {
+            session: session.clone(),
+            key_expr,
+            default_timeout,
+        })
+    }
+
+    /// Call a method on the remote service with typed request and response.
+    ///
+    /// Serializes the request using zenoh-ext `Serialize`, attaches the method
+    /// name and deadline, sends via `session.get()`, and deserializes the response.
+    ///
+    /// # Arguments
+    ///
+    /// * `method` — The RPC method name (must match a handler on the server).
+    /// * `request` — The request payload to serialize.
+    /// * `timeout` — Optional timeout override; uses default if `None`.
+    pub async fn call<Req, Resp>(
+        &self,
+        method: &str,
+        request: &Req,
+        timeout: Option<Duration>,
+    ) -> Result<Resp, ServiceError>
+    where
+        Req: zenoh_ext::Serialize,
+        Resp: zenoh_ext::Deserialize,
+    {
+        let payload = z_serialize(request);
+        let response_bytes = self.call_raw(method, payload, timeout).await?;
+        z_deserialize::<Resp>(&response_bytes).map_err(|_| ServiceError::Internal {
+            message: "failed to deserialize response".to_string(),
+        })
+    }
+
+    /// Call a method with raw `ZBytes` request/response (no serialization).
+    ///
+    /// This is useful when you want to handle serialization yourself or
+    /// forward opaque payloads.
+    ///
+    /// # Arguments
+    ///
+    /// * `method` — The RPC method name.
+    /// * `payload` — The raw request payload.
+    /// * `timeout` — Optional timeout override; uses default if `None`.
+    pub async fn call_raw(
+        &self,
+        method: &str,
+        payload: ZBytes,
+        timeout: Option<Duration>,
+    ) -> Result<ZBytes, ServiceError> {
+        let timeout = timeout.unwrap_or(self.default_timeout);
+
+        // Build attachment map with method name and deadline
+        let (deadline_key, deadline_value) = deadline_attachment(timeout);
+        let attachment_map: HashMap<String, String> = HashMap::from([
+            (METHOD_ATTACHMENT_KEY.to_string(), method.to_string()),
+            (deadline_key, deadline_value),
+        ]);
+        let attachment = z_serialize(&attachment_map);
+
+        // Send the query
+        let replies = self
+            .session
+            .get(&self.key_expr)
+            .payload(payload)
+            .attachment(attachment)
+            .timeout(timeout)
+            .await
+            .map_err(|e| ServiceError::Internal {
+                message: format!("failed to send query: {e}"),
+            })?;
+
+        // Get the first reply
+        let reply = replies.recv_async().await.map_err(|e| ServiceError::Internal {
+            message: format!("failed to receive reply: {e}"),
+        })?;
+
+        // Check if success or error reply.
+        match reply.into_result() {
+            Ok(sample) => {
+                // Check status code attachment if present
+                if let Some(attachment) = sample.attachment() {
+                    if let Ok(map) = z_deserialize::<HashMap<String, String>>(attachment) {
+                        if let Some(status_str) = map.get(STATUS_ATTACHMENT_KEY) {
+                            if let Ok(code) = status_str.parse::<u8>() {
+                                if code != StatusCode::Ok as u8 {
+                                    // Non-OK status on a success reply — unexpected,
+                                    // but treat the payload as data anyway since the
+                                    // server sent it as a success reply.
+                                    tracing::warn!(
+                                        "ServiceClient: success reply has non-OK status code {code}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(sample.payload().clone())
+            }
+            Err(reply_err) => {
+                // Deserialize ServiceError from the error payload
+                let err: ServiceError =
+                    z_deserialize(reply_err.payload()).map_err(|_| ServiceError::Internal {
+                        message: "failed to deserialize error reply".to_string(),
+                    })?;
+                Err(err)
+            }
+        }
+    }
+
+    /// Check if at least one instance of this service is currently available.
+    ///
+    /// Queries liveliness tokens declared by [`ServiceServer`](crate::ServiceServer)
+    /// instances matching this client's key expression.
+    pub async fn is_available(&self) -> zenoh::Result<bool> {
+        let count = self.instance_count().await?;
+        Ok(count > 0)
+    }
+
+    /// Get the count of available service instances.
+    ///
+    /// Queries liveliness tokens declared by [`ServiceServer`](crate::ServiceServer)
+    /// instances matching this client's key expression. Each server declares a
+    /// unique token keyed by its zenoh session ID, so the count reflects the
+    /// number of distinct server instances.
+    pub async fn instance_count(&self) -> zenoh::Result<usize> {
+        let prefix = service_liveliness_prefix(self.key_expr.as_str());
+        let replies = self.session.liveliness().get(&prefix).await?;
+
+        let mut count = 0;
+        while let Ok(reply) = replies.recv_async().await {
+            if reply.result().is_ok() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+}

--- a/zenoh-rpc/src/lib.rs
+++ b/zenoh-rpc/src/lib.rs
@@ -32,10 +32,14 @@
 //! - `default`: Core RPC functionality
 //! - `unstable`: Gated experimental APIs
 
+mod client;
 mod deadline;
 mod discovery;
 mod error;
+mod server;
 
+pub use client::ServiceClient;
 pub use deadline::{deadline_attachment, DeadlineContext, DEADLINE_ATTACHMENT_KEY};
 pub use discovery::{fnv1a_hash, service_liveliness_prefix, service_liveliness_token_key};
 pub use error::{ServiceError, StatusCode};
+pub use server::{MethodHandler, ServiceServer, ServiceServerBuilder, METHOD_ATTACHMENT_KEY};

--- a/zenoh-rpc/src/server.rs
+++ b/zenoh-rpc/src/server.rs
@@ -1,0 +1,288 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use zenoh::bytes::ZBytes;
+use zenoh::key_expr::KeyExpr;
+use zenoh::liveliness::LivelinessToken;
+use zenoh::query::{Query, Queryable};
+use zenoh::session::Session;
+use zenoh::Wait;
+
+use crate::deadline::DeadlineContext;
+use crate::discovery::service_liveliness_token_key;
+use crate::error::{ServiceError, StatusCode};
+use zenoh_ext::{z_deserialize, z_serialize};
+
+/// Attachment key used to identify the RPC method being invoked.
+pub const METHOD_ATTACHMENT_KEY: &str = "rpc:method";
+
+/// Status code attachment key for replies.
+pub(crate) const STATUS_ATTACHMENT_KEY: &str = "rpc:status";
+
+/// Trait for handling a specific RPC method.
+///
+/// Implementors receive the raw [`Query`] and must return either a serialized
+/// response payload or a [`ServiceError`].
+#[async_trait]
+pub trait MethodHandler: Send + Sync {
+    /// Handle an incoming query for this method.
+    async fn handle(&self, query: &Query) -> Result<ZBytes, ServiceError>;
+}
+
+/// Boxed future type alias for method handler closures.
+type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// Wrapper that adapts an async closure into a [`MethodHandler`].
+///
+/// The closure must return a [`BoxFuture`] to erase the lifetime of the
+/// `&Query` reference, matching the `async_trait` desugaring.
+struct MethodFn<F> {
+    f: F,
+}
+
+#[async_trait]
+impl<F> MethodHandler for MethodFn<F>
+where
+    F: for<'a> Fn(&'a Query) -> BoxFuture<'a, Result<ZBytes, ServiceError>> + Send + Sync,
+{
+    async fn handle(&self, query: &Query) -> Result<ZBytes, ServiceError> {
+        (self.f)(query).await
+    }
+}
+
+/// A multi-method RPC server backed by a single zenoh queryable.
+///
+/// The server dispatches incoming queries to registered [`MethodHandler`]s
+/// based on the `rpc:method` attachment on each query. Construct one via
+/// [`ServiceServer::builder`].
+///
+/// The server declares a liveliness token on construction, enabling remote
+/// discovery via [`ServiceClient::is_available`](crate::ServiceClient::is_available) and
+/// [`ServiceClient::instance_count`](crate::ServiceClient::instance_count). The token is automatically undeclared
+/// when the server is dropped.
+pub struct ServiceServer {
+    _queryable: Queryable<()>,
+    _token: LivelinessToken,
+}
+
+/// Builder for [`ServiceServer`].
+///
+/// Register methods via [`method`](Self::method) or [`method_fn`](Self::method_fn),
+/// then `.await` (or call `.wait()`) to start the server.
+pub struct ServiceServerBuilder<'a, 'b> {
+    session: &'a Session,
+    key_expr: zenoh::Result<KeyExpr<'b>>,
+    handlers: HashMap<String, Box<dyn MethodHandler>>,
+}
+
+impl ServiceServer {
+    /// Create a builder for a new `ServiceServer`.
+    ///
+    /// # Arguments
+    ///
+    /// * `session` — The zenoh session to declare the queryable on.
+    /// * `key_expr` — The key expression the server will listen on.
+    pub fn builder<'a, 'b, TryIntoKeyExpr>(
+        session: &'a Session,
+        key_expr: TryIntoKeyExpr,
+    ) -> ServiceServerBuilder<'a, 'b>
+    where
+        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh::Error>,
+    {
+        ServiceServerBuilder {
+            session,
+            key_expr: key_expr.try_into().map_err(Into::into),
+            handlers: HashMap::new(),
+        }
+    }
+}
+
+impl<'a, 'b> ServiceServerBuilder<'a, 'b> {
+    /// Register a method handler.
+    ///
+    /// The `name` is matched against the `rpc:method` attachment on incoming
+    /// queries.
+    pub fn method<H: MethodHandler + 'static>(mut self, name: &str, handler: H) -> Self {
+        self.handlers.insert(name.to_string(), Box::new(handler));
+        self
+    }
+
+    /// Register a method handler from an async closure.
+    ///
+    /// This is a convenience wrapper around [`method`](Self::method) that
+    /// accepts closures returning a boxed future. Use [`Box::pin`] to wrap
+    /// your async block:
+    ///
+    /// ```ignore
+    /// .method_fn("get_config", |query| Box::pin(async move {
+    ///     Ok(ZBytes::from(b"response".as_ref()))
+    /// }))
+    /// ```
+    pub fn method_fn<F>(self, name: &str, f: F) -> Self
+    where
+        F: for<'q> Fn(&'q Query) -> BoxFuture<'q, Result<ZBytes, ServiceError>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.method(name, MethodFn { f })
+    }
+
+    /// Build and start the server.
+    fn build(self) -> zenoh::Result<ServiceServer> {
+        let key_expr = self.key_expr?;
+        let handlers: Arc<HashMap<String, Box<dyn MethodHandler>>> = Arc::new(self.handlers);
+
+        let queryable = self
+            .session
+            .declare_queryable(&key_expr)
+            .callback({
+                let handlers = handlers.clone();
+                move |query| {
+                    let handlers = handlers.clone();
+                    // The callback is sync, so spawn the async dispatch on tokio.
+                    tokio::spawn(async move {
+                        dispatch_query(&handlers, query).await;
+                    });
+                }
+            })
+            .wait()?;
+
+        // Declare a liveliness token for service discovery.
+        // The token key encodes the service key expression hash and this
+        // session's zenoh ID so that remote clients can discover all instances
+        // of a given service.
+        let token_key =
+            service_liveliness_token_key(key_expr.as_str(), &self.session.zid().to_string());
+        let token = self.session.liveliness().declare_token(&token_key).wait()?;
+
+        Ok(ServiceServer {
+            _queryable: queryable,
+            _token: token,
+        })
+    }
+}
+
+impl std::future::IntoFuture for ServiceServerBuilder<'_, '_> {
+    type Output = zenoh::Result<ServiceServer>;
+    type IntoFuture = std::future::Ready<Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        std::future::ready(self.build())
+    }
+}
+
+impl Wait for ServiceServerBuilder<'_, '_> {
+    fn wait(self) -> <Self as zenoh::Resolvable>::To {
+        self.build()
+    }
+}
+
+impl zenoh::Resolvable for ServiceServerBuilder<'_, '_> {
+    type To = zenoh::Result<ServiceServer>;
+}
+
+/// Extract the method name from a query's attachment map.
+fn extract_method(query: &Query) -> Option<String> {
+    let attachment = query.attachment()?;
+    let map: HashMap<String, String> = z_deserialize(attachment).ok()?;
+    map.get(METHOD_ATTACHMENT_KEY).cloned()
+}
+
+/// Build a status-code attachment as serialized `HashMap<String, String>`.
+fn status_attachment(code: StatusCode) -> ZBytes {
+    let map: HashMap<String, String> = HashMap::from([(
+        STATUS_ATTACHMENT_KEY.to_string(),
+        (code as u8).to_string(),
+    )]);
+    z_serialize(&map)
+}
+
+/// Core dispatch logic: read method from attachment, look up handler, call it,
+/// and reply with the result or an appropriate error.
+async fn dispatch_query(handlers: &HashMap<String, Box<dyn MethodHandler>>, query: Query) {
+    // 1. Extract method name from attachment
+    let method = match extract_method(&query) {
+        Some(m) => m,
+        None => {
+            let err = ServiceError::InvalidRequest {
+                message: "missing rpc:method attachment".to_string(),
+            };
+            reply_error(&query, err).await;
+            return;
+        }
+    };
+
+    // 2. Look up handler
+    let handler = match handlers.get(&method) {
+        Some(h) => h,
+        None => {
+            let err = ServiceError::MethodNotFound { method };
+            reply_error(&query, err).await;
+            return;
+        }
+    };
+
+    // 3. Check deadline if present
+    if let Some(ctx) = DeadlineContext::from_query(&query) {
+        if ctx.is_expired() {
+            let err = ServiceError::DeadlineExceeded {
+                budget_ms: ctx.deadline_ms(),
+            };
+            reply_error(&query, err).await;
+            return;
+        }
+    }
+
+    // 4. Call handler
+    match handler.handle(&query).await {
+        Ok(payload) => {
+            reply_success(&query, payload).await;
+        }
+        Err(err) => {
+            reply_error(&query, err).await;
+        }
+    }
+}
+
+/// Send a success reply with status code Ok.
+async fn reply_success(query: &Query, payload: ZBytes) {
+    let attachment = status_attachment(StatusCode::Ok);
+    if let Err(e) = query
+        .reply(query.key_expr(), payload)
+        .attachment(attachment)
+        .await
+    {
+        tracing::warn!("ServiceServer: failed to send success reply: {e}");
+    }
+}
+
+/// Send an error reply with the appropriate status code.
+async fn reply_error(query: &Query, err: ServiceError) {
+    let code = err.status_code();
+    tracing::warn!("ServiceServer: replying with error {code:?}: {err}");
+    let err_payload: ZBytes = err.into();
+    // ReplyErrBuilder does not support attachments, so we serialize the
+    // status code into the error payload prefix. Clients can use
+    // ServiceError deserialization which already includes the status code.
+    if let Err(e) = query.reply_err(err_payload).await {
+        tracing::warn!("ServiceServer: failed to send error reply: {e}");
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `ServiceServer` (builder, method dispatch, liveliness token) to `zenoh-rpc/src/server.rs` (#109)
- Extract `ServiceClient` (typed/raw calls, discovery) to `zenoh-rpc/src/client.rs` (#110)
- Refactor: replace `zenoh::internal::runtime::ZRuntime` with `tokio::spawn` to decouple from internal API (#109)

## Changes
- `zenoh-rpc/src/server.rs` — ServiceServer, ServiceServerBuilder, MethodHandler trait, dispatch logic, reply helpers
- `zenoh-rpc/src/client.rs` — ServiceClient with `call<Req,Resp>`, `call_raw`, `is_available`, `instance_count`
- `zenoh-rpc/src/lib.rs` — module wiring, public re-exports for all server/client types

### Import adjustments (all files)
- `super::` → `crate::` (modules now siblings in zenoh-rpc)
- `crate::{z_serialize, z_deserialize}` → `zenoh_ext::{...}`
- `crate::serialization::Serialize` → `zenoh_ext::Serialize`
- `#[zenoh_macros::unstable]` removed (types are zenoh-rpc's primary API)
- `ZRuntime::Application.spawn(...)` → `tokio::spawn(...)` (removes `zenoh/internal` feature dependency)
- `STATUS_ATTACHMENT_KEY` visibility: `pub(super)` → `pub(crate)`

## Testing
- 25 unit tests pass in zenoh-rpc
- zenoh-ext tests pass with no regressions (21 passed, 4 ignored)
- clippy clean

Closes #109
Closes #110

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->