### PR TITLE
test: add E2E integration tests and usage examples for zenoh-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6500,6 +6500,7 @@ dependencies = [
  "zenoh",
  "zenoh-config",
  "zenoh-ext",
+ "zenoh-util",
 ]
 
 [[package]]

--- a/zenoh-rpc/Cargo.toml
+++ b/zenoh-rpc/Cargo.toml
@@ -46,6 +46,7 @@ zenoh-ext = { workspace = true, default-features = false }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 zenoh-config = { workspace = true }
+zenoh-util = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["unstable"]

--- a/zenoh-rpc/README.md
+++ b/zenoh-rpc/README.md
@@ -44,6 +44,31 @@ trait DeviceConfigService {
 }
 ```
 
+## Examples
+
+Runnable examples are in the [`examples/`](examples/) directory:
+
+| Example | Description |
+|---------|-------------|
+| [`rpc_server`](examples/rpc_server.rs) | Multi-method server with "greet" and "add" handlers, input validation, and error responses |
+| [`rpc_client`](examples/rpc_client.rs) | Typed and raw method calls, plus error handling for invalid input and missing methods |
+| [`rpc_discovery`](examples/rpc_discovery.rs) | Liveliness-based service discovery with `is_available()` and `instance_count()` |
+| [`rpc_deadline`](examples/rpc_deadline.rs) | Deadline propagation from client to server, budget inspection, and expiration handling |
+
+Run the server and client in separate terminals:
+
+```bash
+cargo run --example rpc_server -p zenoh-rpc
+cargo run --example rpc_client -p zenoh-rpc
+```
+
+Or run self-contained examples directly:
+
+```bash
+cargo run --example rpc_discovery -p zenoh-rpc
+cargo run --example rpc_deadline -p zenoh-rpc
+```
+
 ## Feature flags
 
 | Flag | Description |

--- a/zenoh-rpc/examples/rpc_client.rs
+++ b/zenoh-rpc/examples/rpc_client.rs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+/// RPC client example.
+///
+/// Demonstrates how to call methods on a remote `ServiceServer` using
+/// `ServiceClient`. Shows both typed calls (via `call`) and raw/untyped
+/// calls (via `call_raw`), plus error handling for:
+///
+/// - Invalid input (empty name)
+/// - Non-existent methods
+///
+/// Start `rpc_server` first, then run this example.
+///
+/// Usage:
+///   cargo run --example rpc_client -p zenoh-rpc
+use std::time::Duration;
+
+use zenoh_ext::{z_deserialize, z_serialize};
+use zenoh_rpc::{ServiceClient, ServiceError};
+
+const SERVICE_KEY: &str = "demo/rpc";
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    println!("Opening session...");
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    let client = ServiceClient::new(&session, SERVICE_KEY, TIMEOUT)
+        .expect("failed to create ServiceClient");
+
+    // --- Typed call: greet ---
+    println!("\n--- call(\"greet\", \"Alice\") ---");
+    match client
+        .call::<String, String>("greet", &"Alice".to_string(), None)
+        .await
+    {
+        Ok(greeting) => println!("  Response: {greeting}"),
+        Err(e) => eprintln!("  Error: {e}"),
+    }
+
+    // --- Typed call: add ---
+    println!("\n--- call(\"add\", (17, 25)) ---");
+    match client
+        .call::<(i64, i64), i64>("add", &(17, 25), None)
+        .await
+    {
+        Ok(sum) => println!("  Response: {sum}"),
+        Err(e) => eprintln!("  Error: {e}"),
+    }
+
+    // --- Raw/untyped call: add ---
+    // Use call_raw when you want manual control over serialization.
+    println!("\n--- call_raw(\"add\", serialize((100, 200))) ---");
+    let raw_payload = z_serialize(&(100_i64, 200_i64));
+    match client.call_raw("add", raw_payload, None).await {
+        Ok(resp) => {
+            let sum: i64 = z_deserialize(&resp).expect("deserialization failed");
+            println!("  Response (raw): {sum}");
+        }
+        Err(e) => eprintln!("  Error: {e}"),
+    }
+
+    // --- Error case: empty name ---
+    println!("\n--- call(\"greet\", \"\") — expects InvalidRequest ---");
+    match client
+        .call::<String, String>("greet", &String::new(), None)
+        .await
+    {
+        Ok(resp) => println!("  Unexpected success: {resp}"),
+        Err(ServiceError::InvalidRequest { message }) => {
+            println!("  InvalidRequest (expected): {message}");
+        }
+        Err(e) => eprintln!("  Unexpected error variant: {e}"),
+    }
+
+    // --- Error case: non-existent method ---
+    println!("\n--- call(\"multiply\", (2, 3)) — expects MethodNotFound ---");
+    match client
+        .call::<(i64, i64), i64>("multiply", &(2, 3), None)
+        .await
+    {
+        Ok(resp) => println!("  Unexpected success: {resp}"),
+        Err(ServiceError::MethodNotFound { method }) => {
+            println!("  MethodNotFound (expected): {method}");
+        }
+        Err(e) => eprintln!("  Unexpected error variant: {e}"),
+    }
+
+    println!("\nDone.");
+}

--- a/zenoh-rpc/examples/rpc_deadline.rs
+++ b/zenoh-rpc/examples/rpc_deadline.rs
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+/// Deadline propagation example.
+///
+/// Demonstrates how deadline budgets flow from client to server:
+///
+/// 1. A server method inspects the remaining deadline budget via
+///    `DeadlineContext::from_query` and includes it in the response.
+/// 2. A client calls the method with a generous timeout (5 s) and the
+///    server reports the remaining budget.
+/// 3. A client calls the method with a very short timeout (10 ms). The
+///    server's automatic deadline check rejects the request before the
+///    handler runs, returning `ServiceError::DeadlineExceeded`.
+///
+/// Usage:
+///   cargo run --example rpc_deadline -p zenoh-rpc
+use std::time::Duration;
+
+use zenoh_ext::z_serialize;
+use zenoh_rpc::{DeadlineContext, ServiceClient, ServiceError, ServiceServer};
+
+const SERVICE_KEY: &str = "demo/deadline";
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    println!("Opening session...");
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    // --- Server: "slow_work" reports remaining budget ---
+    println!("Starting RPC server on '{SERVICE_KEY}'...");
+    let _server = ServiceServer::builder(&session, SERVICE_KEY)
+        .method_fn("slow_work", |query| {
+            Box::pin(async move {
+                // Extract deadline context from the query attachment.
+                // The server framework already checks for expiration before
+                // calling the handler, but we can also inspect the budget
+                // for logging or sub-task scheduling.
+                let remaining = match DeadlineContext::from_query(query) {
+                    Some(ctx) => {
+                        let r = ctx.remaining();
+                        println!("  [server] remaining budget: {r:?}");
+                        r
+                    }
+                    None => {
+                        println!("  [server] no deadline attached");
+                        Duration::ZERO
+                    }
+                };
+
+                // Simulate work that takes 50 ms
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                // Return the remaining budget (in ms) as the response so the
+                // client can see what the server observed.
+                let remaining_ms = remaining.as_millis() as u64;
+                Ok(z_serialize(&remaining_ms))
+            })
+        })
+        .await
+        .unwrap();
+
+    let client = ServiceClient::new(&session, SERVICE_KEY, Duration::from_secs(5))
+        .expect("failed to create ServiceClient");
+
+    // --- Call 1: generous timeout (5 s default) ---
+    println!("\n--- call(\"slow_work\") with 5 s timeout ---");
+    match client
+        .call::<String, u64>("slow_work", &String::new(), None)
+        .await
+    {
+        Ok(remaining_ms) => {
+            println!("  Server reported {remaining_ms} ms remaining budget");
+        }
+        Err(e) => eprintln!("  Error: {e}"),
+    }
+
+    // --- Call 2: explicit short timeout (10 ms) ---
+    // The client sends a deadline that is only 10 ms from now. By the time
+    // the query reaches the server, the deadline is likely already expired.
+    // The server framework rejects it with DeadlineExceeded before the
+    // handler runs.
+    println!("\n--- call(\"slow_work\") with 10 ms timeout (expect DeadlineExceeded) ---");
+    // Small sleep to ensure the query has time to expire in transit
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    match client
+        .call::<String, u64>(
+            "slow_work",
+            &String::new(),
+            Some(Duration::from_millis(10)),
+        )
+        .await
+    {
+        Ok(remaining_ms) => {
+            println!("  Unexpected success: server reported {remaining_ms} ms remaining");
+        }
+        Err(ServiceError::DeadlineExceeded { budget_ms }) => {
+            println!("  DeadlineExceeded (expected): budget was {budget_ms} ms");
+        }
+        Err(e) => {
+            // On a fast local machine the query might arrive before expiry,
+            // or the zenoh timeout might fire first. Both are valid outcomes.
+            eprintln!("  Other error (acceptable on fast machines): {e}");
+        }
+    }
+
+    // --- Call 3: demonstrate reading the budget in the handler ---
+    println!("\n--- call(\"slow_work\") with 2 s explicit timeout ---");
+    match client
+        .call::<String, u64>(
+            "slow_work",
+            &String::new(),
+            Some(Duration::from_secs(2)),
+        )
+        .await
+    {
+        Ok(remaining_ms) => {
+            println!("  Server reported {remaining_ms} ms remaining budget");
+            println!("  (expected close to 2000 ms, minus transit time)");
+        }
+        Err(e) => eprintln!("  Error: {e}"),
+    }
+
+    println!("\nDone.");
+}

--- a/zenoh-rpc/examples/rpc_discovery.rs
+++ b/zenoh-rpc/examples/rpc_discovery.rs
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+/// Service discovery example.
+///
+/// Demonstrates how to discover running `ServiceServer` instances using the
+/// liveliness-based discovery built into `ServiceClient`. The example:
+///
+/// 1. Checks availability before any server is started (expects 0 instances).
+/// 2. Starts a server, then re-checks (expects 1 instance).
+/// 3. Starts a second server on the same key expression (expects 2 instances).
+/// 4. Drops a server and verifies the count decreases.
+///
+/// All servers and clients share a single zenoh session in this example for
+/// simplicity. In production, servers typically run in separate processes.
+///
+/// Usage:
+///   cargo run --example rpc_discovery -p zenoh-rpc
+use std::time::Duration;
+
+use zenoh::bytes::ZBytes;
+use zenoh_rpc::{ServiceClient, ServiceServer};
+
+const SERVICE_KEY: &str = "demo/discovery";
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    println!("Opening session...");
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    let client = ServiceClient::new(&session, SERVICE_KEY, Duration::from_secs(5))
+        .expect("failed to create ServiceClient");
+
+    // --- Step 1: No servers running ---
+    println!("\n--- Before starting any server ---");
+    let available = client.is_available().await.expect("is_available failed");
+    let count = client.instance_count().await.expect("instance_count failed");
+    println!("  is_available: {available}");
+    println!("  instance_count: {count}");
+
+    // --- Step 2: Start one server ---
+    println!("\n--- Starting server #1 ---");
+    let server1 = ServiceServer::builder(&session, SERVICE_KEY)
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong".as_ref())) })
+        })
+        .await
+        .expect("failed to start server 1");
+
+    // Small delay so liveliness propagates
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let available = client.is_available().await.expect("is_available failed");
+    let count = client.instance_count().await.expect("instance_count failed");
+    println!("  is_available: {available}");
+    println!("  instance_count: {count}");
+
+    // --- Step 3: Start a second server (same key expression, different session) ---
+    println!("\n--- Starting server #2 (new session) ---");
+    let session2 = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let server2 = ServiceServer::builder(&session2, SERVICE_KEY)
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong".as_ref())) })
+        })
+        .await
+        .expect("failed to start server 2");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let count = client.instance_count().await.expect("instance_count failed");
+    println!("  instance_count: {count}");
+
+    // --- Step 4: Drop server #1, count should decrease ---
+    println!("\n--- Dropping server #1 ---");
+    drop(server1);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let count = client.instance_count().await.expect("instance_count failed");
+    println!("  instance_count: {count}");
+
+    // --- Cleanup ---
+    println!("\n--- Dropping server #2 ---");
+    drop(server2);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let available = client.is_available().await.expect("is_available failed");
+    println!("  is_available: {available}");
+
+    println!("\nDone.");
+}

--- a/zenoh-rpc/examples/rpc_server.rs
+++ b/zenoh-rpc/examples/rpc_server.rs
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+/// RPC server example.
+///
+/// Demonstrates how to create a multi-method RPC server using `ServiceServer`.
+/// The server registers two methods:
+///
+/// - **"greet"** — accepts a name (String) and returns a greeting.
+/// - **"add"** — accepts a pair of i64 values and returns their sum.
+///
+/// The server also validates inputs, returning `ServiceError::InvalidRequest`
+/// when the name is empty. Run this alongside `rpc_client` to see the full
+/// request-response cycle.
+///
+/// Usage:
+///   cargo run --example rpc_server -p zenoh-rpc
+use zenoh_ext::{z_deserialize, z_serialize};
+use zenoh_rpc::{ServiceError, ServiceServer};
+
+const SERVICE_KEY: &str = "demo/rpc";
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    println!("Opening session...");
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    println!("Starting RPC server on '{SERVICE_KEY}'...");
+    let _server = ServiceServer::builder(&session, SERVICE_KEY)
+        // "greet" method: takes a name, returns a greeting string.
+        .method_fn("greet", |query| {
+            Box::pin(async move {
+                // Deserialize the name from the query payload
+                let payload = query
+                    .payload()
+                    .ok_or_else(|| ServiceError::InvalidRequest {
+                        message: "missing payload".to_string(),
+                    })?;
+                let name: String =
+                    z_deserialize(payload).map_err(|_| ServiceError::InvalidRequest {
+                        message: "payload is not a valid string".to_string(),
+                    })?;
+
+                // Validate input — demonstrate returning an error
+                if name.is_empty() {
+                    return Err(ServiceError::InvalidRequest {
+                        message: "name must not be empty".to_string(),
+                    });
+                }
+
+                let greeting = format!("Hello, {name}! Welcome to zenoh-rpc.");
+                println!("  greet({name:?}) -> {greeting:?}");
+                Ok(z_serialize(&greeting))
+            })
+        })
+        // "add" method: takes (i64, i64), returns i64.
+        .method_fn("add", |query| {
+            Box::pin(async move {
+                let payload = query
+                    .payload()
+                    .ok_or_else(|| ServiceError::InvalidRequest {
+                        message: "missing payload".to_string(),
+                    })?;
+                let (a, b): (i64, i64) =
+                    z_deserialize(payload).map_err(|_| ServiceError::InvalidRequest {
+                        message: "payload is not a valid (i64, i64) tuple".to_string(),
+                    })?;
+
+                let result = a + b;
+                println!("  add({a}, {b}) -> {result}");
+                Ok(z_serialize(&result))
+            })
+        })
+        .await
+        .unwrap();
+
+    println!("RPC server running. Press CTRL-C to quit.");
+
+    // Keep the server alive until interrupted.
+    // Use a pending future — the process terminates via SIGINT.
+    std::future::pending::<()>().await;
+}

--- a/zenoh-rpc/tests/rpc.rs
+++ b/zenoh-rpc/tests/rpc.rs
@@ -1,0 +1,297 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::time::Duration;
+
+use zenoh_ext::{z_deserialize, z_serialize};
+use zenoh_rpc::{deadline_attachment, DeadlineContext, ServiceError, StatusCode, DEADLINE_ATTACHMENT_KEY};
+
+// -- Round-trip serialization for each variant --
+
+#[test]
+fn service_error_round_trip_invalid_request() {
+    let err = ServiceError::InvalidRequest {
+        message: "field 'name' is required".to_string(),
+    };
+    let zbytes = z_serialize(&err);
+    let recovered: ServiceError = z_deserialize(&zbytes).expect("deserialization failed");
+    assert_eq!(recovered, err);
+}
+
+#[test]
+fn service_error_round_trip_not_found() {
+    let err = ServiceError::NotFound {
+        message: "device 42".to_string(),
+    };
+    let zbytes = z_serialize(&err);
+    let recovered: ServiceError = z_deserialize(&zbytes).expect("deserialization failed");
+    assert_eq!(recovered, err);
+}
+
+#[test]
+fn service_error_round_trip_deadline_exceeded() {
+    let err = ServiceError::DeadlineExceeded { budget_ms: 5000 };
+    let zbytes = z_serialize(&err);
+    let recovered: ServiceError = z_deserialize(&zbytes).expect("deserialization failed");
+    assert_eq!(recovered, err);
+}
+
+#[test]
+fn service_error_round_trip_internal() {
+    let err = ServiceError::Internal {
+        message: "unexpected null pointer".to_string(),
+    };
+    let zbytes = z_serialize(&err);
+    let recovered: ServiceError = z_deserialize(&zbytes).expect("deserialization failed");
+    assert_eq!(recovered, err);
+}
+
+#[test]
+fn service_error_round_trip_method_not_found() {
+    let err = ServiceError::MethodNotFound {
+        method: "rpc/getConfig".to_string(),
+    };
+    let zbytes = z_serialize(&err);
+    let recovered: ServiceError = z_deserialize(&zbytes).expect("deserialization failed");
+    assert_eq!(recovered, err);
+}
+
+#[test]
+fn service_error_round_trip_application() {
+    let err = ServiceError::Application {
+        code: 429,
+        message: "rate limit exceeded".to_string(),
+    };
+    let zbytes = z_serialize(&err);
+    let recovered: ServiceError = z_deserialize(&zbytes).expect("deserialization failed");
+    assert_eq!(recovered, err);
+}
+
+// -- status_code() returns correct code for each variant --
+
+#[test]
+fn status_code_matches_variant() {
+    let cases: Vec<(ServiceError, StatusCode)> = vec![
+        (
+            ServiceError::InvalidRequest {
+                message: String::new(),
+            },
+            StatusCode::InvalidRequest,
+        ),
+        (
+            ServiceError::NotFound {
+                message: String::new(),
+            },
+            StatusCode::NotFound,
+        ),
+        (
+            ServiceError::DeadlineExceeded { budget_ms: 0 },
+            StatusCode::DeadlineExceeded,
+        ),
+        (
+            ServiceError::Internal {
+                message: String::new(),
+            },
+            StatusCode::Internal,
+        ),
+        (
+            ServiceError::MethodNotFound {
+                method: String::new(),
+            },
+            StatusCode::MethodNotFound,
+        ),
+        (
+            ServiceError::Application {
+                code: 0,
+                message: String::new(),
+            },
+            StatusCode::Application,
+        ),
+    ];
+
+    for (err, expected_code) in cases {
+        assert_eq!(
+            err.status_code(),
+            expected_code,
+            "wrong status code for {err:?}"
+        );
+    }
+}
+
+// -- Display formatting is human-readable --
+
+#[test]
+fn display_is_human_readable() {
+    assert_eq!(
+        ServiceError::InvalidRequest {
+            message: "bad".to_string()
+        }
+        .to_string(),
+        "invalid request: bad"
+    );
+
+    assert_eq!(
+        ServiceError::NotFound {
+            message: "key".to_string()
+        }
+        .to_string(),
+        "not found: key"
+    );
+
+    assert_eq!(
+        ServiceError::DeadlineExceeded { budget_ms: 100 }.to_string(),
+        "deadline exceeded: budget was 100ms"
+    );
+
+    assert_eq!(
+        ServiceError::Internal {
+            message: "boom".to_string()
+        }
+        .to_string(),
+        "internal error: boom"
+    );
+
+    assert_eq!(
+        ServiceError::MethodNotFound {
+            method: "doStuff".to_string()
+        }
+        .to_string(),
+        "method not found: doStuff"
+    );
+
+    assert_eq!(
+        ServiceError::Application {
+            code: 503,
+            message: "unavailable".to_string()
+        }
+        .to_string(),
+        "application error (503): unavailable"
+    );
+}
+
+// -- ZBytes ergonomic conversion --
+
+#[test]
+fn zbytes_conversion_round_trip() {
+    use zenoh::bytes::ZBytes;
+
+    let err = ServiceError::Application {
+        code: 1001,
+        message: "quota exceeded".to_string(),
+    };
+    let zbytes: ZBytes = err.clone().into();
+    let recovered = ServiceError::try_from(zbytes).expect("conversion failed");
+    assert_eq!(recovered, err);
+}
+
+// -- Error trait is implemented --
+
+#[test]
+fn implements_std_error() {
+    let err = ServiceError::Internal {
+        message: "test".to_string(),
+    };
+    // Verify it can be used as a dyn Error
+    let _: &dyn std::error::Error = &err;
+}
+
+// -- DeadlineContext tests --
+
+#[test]
+fn deadline_context_remaining_returns_positive_for_future_deadline() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Set the deadline 10 seconds from now
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64;
+    let ctx = DeadlineContext::from_millis(now_ms + 10_000);
+
+    let remaining = ctx.remaining();
+    // Should be close to 10 seconds (allow some margin for test execution)
+    assert!(remaining > Duration::from_secs(9), "remaining: {remaining:?}");
+    assert!(
+        remaining <= Duration::from_secs(10),
+        "remaining: {remaining:?}"
+    );
+}
+
+#[test]
+fn deadline_context_remaining_returns_zero_for_past_deadline() {
+    // Set the deadline 10 seconds in the past
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64;
+    let ctx = DeadlineContext::from_millis(now_ms.saturating_sub(10_000));
+
+    assert_eq!(ctx.remaining(), Duration::ZERO);
+}
+
+#[test]
+fn deadline_context_is_expired_for_past_deadline() {
+    // Deadline at UNIX epoch — long expired
+    let ctx = DeadlineContext::from_millis(0);
+    assert!(ctx.is_expired());
+}
+
+#[test]
+fn deadline_context_is_not_expired_for_future_deadline() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64;
+    let ctx = DeadlineContext::from_millis(now_ms + 60_000);
+
+    assert!(!ctx.is_expired());
+}
+
+#[test]
+fn deadline_attachment_produces_valid_key_value() {
+    let timeout = Duration::from_secs(5);
+    let (key, value) = deadline_attachment(timeout);
+
+    assert_eq!(key, DEADLINE_ATTACHMENT_KEY);
+
+    // The value should be parseable as u64 and be in the future
+    let deadline_ms: u64 = value.parse().expect("value should be a valid u64");
+
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64;
+
+    // The deadline should be approximately now + 5 seconds (allow 1 second margin)
+    assert!(
+        deadline_ms >= now_ms + 4_000,
+        "deadline_ms {deadline_ms} should be >= now + 4s ({now_ms})"
+    );
+    assert!(
+        deadline_ms <= now_ms + 6_000,
+        "deadline_ms {deadline_ms} should be <= now + 6s ({now_ms})"
+    );
+}
+
+#[test]
+fn deadline_context_from_millis_roundtrip() {
+    let original_ms: u64 = 1_700_000_000_000; // ~2023-11-14
+    let ctx = DeadlineContext::from_millis(original_ms);
+    assert_eq!(ctx.deadline_ms(), original_ms);
+}

--- a/zenoh-rpc/tests/rpc_client.rs
+++ b/zenoh-rpc/tests/rpc_client.rs
@@ -1,0 +1,332 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::time::Duration;
+
+use zenoh::bytes::ZBytes;
+
+use zenoh_ext::{z_deserialize, z_serialize};
+use zenoh_rpc::{
+    DeadlineContext, ServiceClient, ServiceError, ServiceServer, DEADLINE_ATTACHMENT_KEY,
+    METHOD_ATTACHMENT_KEY,
+};
+
+/// Unique key expression generator to avoid cross-test interference.
+fn unique_ke(suffix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("test/rpc/client/{id}/{suffix}")
+}
+
+// -- Test: typed call with ServiceClient and ServiceServer --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_call_returns_typed_response() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("typed");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("greet", |query| {
+            Box::pin(async move {
+                let name: String = query
+                    .payload()
+                    .map(|p| z_deserialize(p).unwrap())
+                    .unwrap_or_default();
+                let greeting = format!("Hello, {name}!");
+                Ok(z_serialize(&greeting))
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let response: String = client
+        .call("greet", &"World".to_string(), None)
+        .await
+        .expect("call should succeed");
+    assert_eq!(response, "Hello, World!");
+}
+
+// -- Test: raw call with ServiceClient and ServiceServer --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn raw_call_returns_raw_response() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("raw");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("echo", |query| {
+            let payload = query
+                .payload()
+                .map(|p| p.to_bytes().to_vec())
+                .unwrap_or_default();
+            Box::pin(async move { Ok(ZBytes::from(payload)) })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let request = ZBytes::from(b"raw bytes here".as_ref());
+    let response = client
+        .call_raw("echo", request, None)
+        .await
+        .expect("call_raw should succeed");
+    assert_eq!(response.to_bytes().as_ref(), b"raw bytes here");
+}
+
+// -- Test: call non-existent method returns MethodNotFound --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn call_nonexistent_method_returns_method_not_found() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("not_found");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("exists", |_query| {
+            Box::pin(async { Ok(ZBytes::default()) })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let result = client
+        .call_raw("nonexistent", ZBytes::default(), None)
+        .await;
+
+    match result {
+        Err(ServiceError::MethodNotFound { method }) => {
+            assert_eq!(method, "nonexistent");
+        }
+        other => panic!("expected MethodNotFound, got {other:?}"),
+    }
+}
+
+// -- Test: deadline attachment is set on the query (server-side check) --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deadline_attachment_is_set_on_query() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("deadline");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("check_deadline", |query| {
+            Box::pin(async move {
+                // Extract the deadline from the query's attachment
+                let ctx = DeadlineContext::from_query(query)
+                    .ok_or_else(|| ServiceError::Internal {
+                        message: "no deadline attachment found".to_string(),
+                    })?;
+
+                // The deadline should not be expired (we just sent the query)
+                if ctx.is_expired() {
+                    return Err(ServiceError::Internal {
+                        message: "deadline already expired".to_string(),
+                    });
+                }
+
+                // Return the remaining budget in ms
+                let remaining_ms = ctx.remaining().as_millis() as u64;
+                Ok(z_serialize(&remaining_ms))
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(10)).expect("client should build");
+
+    let remaining_ms: u64 = client
+        .call("check_deadline", &(), None)
+        .await
+        .expect("call should succeed");
+
+    // The remaining budget should be close to 10 seconds (allow margin)
+    assert!(
+        remaining_ms > 8_000,
+        "remaining_ms {remaining_ms} should be > 8000"
+    );
+    assert!(
+        remaining_ms <= 10_000,
+        "remaining_ms {remaining_ms} should be <= 10000"
+    );
+}
+
+// -- Test: client with custom timeout overrides default --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_timeout_overrides_default() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("custom_timeout");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("check_deadline", |query| {
+            Box::pin(async move {
+                let ctx = DeadlineContext::from_query(query)
+                    .ok_or_else(|| ServiceError::Internal {
+                        message: "no deadline attachment".to_string(),
+                    })?;
+                let remaining_ms = ctx.remaining().as_millis() as u64;
+                Ok(z_serialize(&remaining_ms))
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Default timeout is 1 second, but we override with 20 seconds
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(1)).expect("client should build");
+
+    let remaining_ms: u64 = client
+        .call("check_deadline", &(), Some(Duration::from_secs(20)))
+        .await
+        .expect("call should succeed");
+
+    // The remaining budget should be close to 20 seconds (not 1 second)
+    assert!(
+        remaining_ms > 18_000,
+        "remaining_ms {remaining_ms} should be > 18000 (override should use 20s, not default 1s)"
+    );
+}
+
+// -- Test: handler error is propagated through client --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handler_error_is_propagated_through_client() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("handler_error");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("fail", |_query| {
+            Box::pin(async {
+                Err(ServiceError::Application {
+                    code: 503,
+                    message: "service unavailable".to_string(),
+                })
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let result = client.call_raw("fail", ZBytes::default(), None).await;
+
+    match result {
+        Err(ServiceError::Application { code, message }) => {
+            assert_eq!(code, 503);
+            assert_eq!(message, "service unavailable");
+        }
+        other => panic!("expected Application error, got {other:?}"),
+    }
+}
+
+// -- Test: method attachment key is present in client queries --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn method_attachment_is_present() {
+    use std::collections::HashMap;
+
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("method_attachment");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("inspect", |query| {
+            Box::pin(async move {
+                // Extract the full attachment map and return the method value
+                let attachment = query.attachment().ok_or_else(|| ServiceError::Internal {
+                    message: "no attachment".to_string(),
+                })?;
+                let map: HashMap<String, String> =
+                    z_deserialize(attachment).map_err(|_| ServiceError::Internal {
+                        message: "failed to deserialize attachment".to_string(),
+                    })?;
+                let method = map
+                    .get(METHOD_ATTACHMENT_KEY)
+                    .cloned()
+                    .unwrap_or_default();
+                let has_deadline = map.contains_key(DEADLINE_ATTACHMENT_KEY);
+                let result = format!("{method}:{has_deadline}");
+                Ok(z_serialize(&result))
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let result: String = client
+        .call("inspect", &(), None)
+        .await
+        .expect("call should succeed");
+
+    // Method name should be "inspect" and deadline should be present
+    assert_eq!(result, "inspect:true");
+}
+
+// -- Test: multiple sequential calls work correctly --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multiple_sequential_calls() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("sequential");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("add_one", |query| {
+            Box::pin(async move {
+                let n: u64 = query
+                    .payload()
+                    .map(|p| z_deserialize(p).unwrap())
+                    .unwrap_or(0);
+                Ok(z_serialize(&(n + 1)))
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client =
+        ServiceClient::new(&session, &ke, Duration::from_secs(5)).expect("client should build");
+
+    for i in 0u64..5 {
+        let result: u64 = client
+            .call("add_one", &i, None)
+            .await
+            .expect("call should succeed");
+        assert_eq!(result, i + 1, "call {i} returned wrong value");
+    }
+}

--- a/zenoh-rpc/tests/rpc_discovery.rs
+++ b/zenoh-rpc/tests/rpc_discovery.rs
@@ -1,0 +1,218 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::time::Duration;
+
+use zenoh::bytes::ZBytes;
+
+use zenoh_rpc::{ServiceClient, ServiceServer};
+
+/// Create a peer session with multicast scouting disabled and listening on
+/// the given endpoint.
+async fn listening_session(endpoint: &str) -> zenoh::Session {
+    let mut config = zenoh::Config::default();
+    config
+        .insert_json5("mode", "\"peer\"")
+        .unwrap();
+    config
+        .insert_json5("listen/endpoints", &format!("[\"{endpoint}\"]"))
+        .unwrap();
+    config
+        .insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+    zenoh::open(config).await.unwrap()
+}
+
+/// Create a peer session with multicast scouting disabled that connects to
+/// the given endpoint.
+async fn connecting_session(endpoint: &str) -> zenoh::Session {
+    let mut config = zenoh::Config::default();
+    config
+        .insert_json5("mode", "\"peer\"")
+        .unwrap();
+    config
+        .insert_json5("connect/endpoints", &format!("[\"{endpoint}\"]"))
+        .unwrap();
+    config
+        .insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+    zenoh::open(config).await.unwrap()
+}
+
+/// Unique key expression generator to avoid cross-test interference.
+fn unique_ke(suffix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("test/rpc/discovery/{id}/{suffix}")
+}
+
+// -- Test: server is discoverable after start --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn server_is_available_after_start() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:17501";
+    let ke = unique_ke("available");
+
+    let session1 = listening_session(ENDPOINT).await;
+    let session2 = connecting_session(ENDPOINT).await;
+
+    // Start the server
+    let _server = ServiceServer::builder(&session1, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong".as_ref())) })
+        })
+        .await
+        .expect("server should start");
+
+    // Allow liveliness token to propagate
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Client on a different session should see the server
+    let client =
+        ServiceClient::new(&session2, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let available = client.is_available().await.expect("is_available should work");
+    assert!(available, "server should be available");
+
+    session1.close().await.unwrap();
+    session2.close().await.unwrap();
+}
+
+// -- Test: no server means not available --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_server_is_not_available() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:17502";
+    let ke = unique_ke("not_available");
+
+    let session1 = listening_session(ENDPOINT).await;
+    let session2 = connecting_session(ENDPOINT).await;
+
+    // Allow sessions to establish connectivity
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // No server is started — client should see nothing
+    let client =
+        ServiceClient::new(&session2, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let available = client.is_available().await.expect("is_available should work");
+    assert!(!available, "no server should mean not available");
+
+    session1.close().await.unwrap();
+    session2.close().await.unwrap();
+}
+
+// -- Test: two servers on the same key report instance_count == 2 --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_servers_report_instance_count_two() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:17503";
+    let ke = unique_ke("two_instances");
+
+    let session1 = listening_session(ENDPOINT).await;
+    let session2 = connecting_session(ENDPOINT).await;
+    let session3 = connecting_session(ENDPOINT).await;
+
+    // Start two servers on the same key expression but different sessions
+    let _server1 = ServiceServer::builder(&session1, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong1".as_ref())) })
+        })
+        .await
+        .expect("server1 should start");
+
+    let _server2 = ServiceServer::builder(&session2, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong2".as_ref())) })
+        })
+        .await
+        .expect("server2 should start");
+
+    // Allow liveliness tokens to propagate
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let client =
+        ServiceClient::new(&session3, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let count = client
+        .instance_count()
+        .await
+        .expect("instance_count should work");
+    assert_eq!(count, 2, "should see 2 server instances");
+
+    session1.close().await.unwrap();
+    session2.close().await.unwrap();
+    session3.close().await.unwrap();
+}
+
+// -- Test: dropping a server decreases the count --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dropping_server_decreases_count() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:17504";
+    let ke = unique_ke("drop_count");
+
+    let session1 = listening_session(ENDPOINT).await;
+    let session2 = connecting_session(ENDPOINT).await;
+    let session3 = connecting_session(ENDPOINT).await;
+
+    let _server1 = ServiceServer::builder(&session1, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong1".as_ref())) })
+        })
+        .await
+        .expect("server1 should start");
+
+    let server2 = ServiceServer::builder(&session2, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong2".as_ref())) })
+        })
+        .await
+        .expect("server2 should start");
+
+    // Allow liveliness tokens to propagate
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let client =
+        ServiceClient::new(&session3, &ke, Duration::from_secs(5)).expect("client should build");
+
+    let count = client
+        .instance_count()
+        .await
+        .expect("instance_count should work");
+    assert_eq!(count, 2, "should see 2 server instances initially");
+
+    // Drop server2 — its liveliness token should be undeclared
+    drop(server2);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let count = client
+        .instance_count()
+        .await
+        .expect("instance_count should work");
+    assert_eq!(count, 1, "should see 1 server instance after dropping one");
+
+    session1.close().await.unwrap();
+    session2.close().await.unwrap();
+    session3.close().await.unwrap();
+}

--- a/zenoh-rpc/tests/rpc_e2e.rs
+++ b/zenoh-rpc/tests/rpc_e2e.rs
@@ -1,0 +1,516 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::time::Duration;
+
+use zenoh::bytes::ZBytes;
+
+use zenoh_ext::{
+    z_deserialize, z_serialize, Deserialize, Serialize, ZDeserializeError, ZDeserializer,
+    ZSerializer,
+};
+use zenoh_rpc::{ServiceClient, ServiceError, ServiceServer};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+macro_rules! ztimeout {
+    ($f:expr) => {
+        tokio::time::timeout(TIMEOUT, ::core::future::IntoFuture::into_future($f))
+            .await
+            .unwrap()
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Shared test types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GreetRequest {
+    name: String,
+}
+
+impl Serialize for GreetRequest {
+    fn serialize(&self, serializer: &mut ZSerializer) {
+        serializer.serialize(&self.name);
+    }
+}
+
+impl Deserialize for GreetRequest {
+    fn deserialize(deserializer: &mut ZDeserializer) -> Result<Self, ZDeserializeError> {
+        Ok(Self {
+            name: deserializer.deserialize()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GreetResponse {
+    message: String,
+}
+
+impl Serialize for GreetResponse {
+    fn serialize(&self, serializer: &mut ZSerializer) {
+        serializer.serialize(&self.message);
+    }
+}
+
+impl Deserialize for GreetResponse {
+    fn deserialize(deserializer: &mut ZDeserializer) -> Result<Self, ZDeserializeError> {
+        Ok(Self {
+            message: deserializer.deserialize()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AddRequest {
+    a: i32,
+    b: i32,
+}
+
+impl Serialize for AddRequest {
+    fn serialize(&self, serializer: &mut ZSerializer) {
+        serializer.serialize(self.a);
+        serializer.serialize(self.b);
+    }
+}
+
+impl Deserialize for AddRequest {
+    fn deserialize(deserializer: &mut ZDeserializer) -> Result<Self, ZDeserializeError> {
+        Ok(Self {
+            a: deserializer.deserialize()?,
+            b: deserializer.deserialize()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AddResponse {
+    sum: i32,
+}
+
+impl Serialize for AddResponse {
+    fn serialize(&self, serializer: &mut ZSerializer) {
+        serializer.serialize(self.sum);
+    }
+}
+
+impl Deserialize for AddResponse {
+    fn deserialize(deserializer: &mut ZDeserializer) -> Result<Self, ZDeserializeError> {
+        Ok(Self {
+            sum: deserializer.deserialize()?,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session helpers
+// ---------------------------------------------------------------------------
+
+/// Create a peer session that listens on the given TCP endpoint with multicast
+/// scouting disabled.
+async fn listening_session(endpoint: &str) -> zenoh::Session {
+    let mut config = zenoh::Config::default();
+    config
+        .insert_json5("mode", "\"peer\"")
+        .unwrap();
+    config
+        .insert_json5("listen/endpoints", &format!("[\"{endpoint}\"]"))
+        .unwrap();
+    config
+        .insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+    ztimeout!(zenoh::open(config)).unwrap()
+}
+
+/// Create a peer session that connects to the given TCP endpoint with multicast
+/// scouting disabled.
+async fn connecting_session(endpoint: &str) -> zenoh::Session {
+    let mut config = zenoh::Config::default();
+    config
+        .insert_json5("mode", "\"peer\"")
+        .unwrap();
+    config
+        .insert_json5("connect/endpoints", &format!("[\"{endpoint}\"]"))
+        .unwrap();
+    config
+        .insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+    ztimeout!(zenoh::open(config)).unwrap()
+}
+
+/// Generate a unique key expression per test to avoid cross-test interference.
+fn unique_ke(suffix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("test/rpc/e2e/{id}/{suffix}")
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path: client -> server -> typed response
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn happy_path_greet_and_add() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:27500";
+    let ke = unique_ke("happy_path");
+
+    let server_session = listening_session(ENDPOINT).await;
+    let client_session = connecting_session(ENDPOINT).await;
+
+    // Register a server with two methods: "greet" and "add"
+    let _server = ztimeout!(ServiceServer::builder(&server_session, ke.as_str())
+        .method_fn("greet", |query| {
+            Box::pin(async move {
+                let req: GreetRequest = query
+                    .payload()
+                    .map(z_deserialize)
+                    .transpose()
+                    .map_err(|_| ServiceError::InvalidRequest {
+                        message: "failed to deserialize GreetRequest".to_string(),
+                    })?
+                    .ok_or_else(|| ServiceError::InvalidRequest {
+                        message: "missing request payload".to_string(),
+                    })?;
+                let resp = GreetResponse {
+                    message: format!("Hello, {}!", req.name),
+                };
+                Ok(z_serialize(&resp))
+            })
+        })
+        .method_fn("add", |query| {
+            Box::pin(async move {
+                let req: AddRequest = query
+                    .payload()
+                    .map(z_deserialize)
+                    .transpose()
+                    .map_err(|_| ServiceError::InvalidRequest {
+                        message: "failed to deserialize AddRequest".to_string(),
+                    })?
+                    .ok_or_else(|| ServiceError::InvalidRequest {
+                        message: "missing request payload".to_string(),
+                    })?;
+                let resp = AddResponse { sum: req.a + req.b };
+                Ok(z_serialize(&resp))
+            })
+        }))
+    .expect("server should start");
+
+    // Allow the queryable to propagate
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = ServiceClient::new(&client_session, &ke, Duration::from_secs(5))
+        .expect("client should build");
+
+    // Call "greet"
+    let greet_resp: GreetResponse = client
+        .call(
+            "greet",
+            &GreetRequest {
+                name: "Zenoh".to_string(),
+            },
+            None,
+        )
+        .await
+        .expect("greet call should succeed");
+    assert_eq!(greet_resp.message, "Hello, Zenoh!");
+
+    // Call "add"
+    let add_resp: AddResponse = client
+        .call("add", &AddRequest { a: 17, b: 25 }, None)
+        .await
+        .expect("add call should succeed");
+    assert_eq!(add_resp.sum, 42);
+
+    ztimeout!(server_session.close()).unwrap();
+    ztimeout!(client_session.close()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 2. Structured error: server returns ServiceError
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn structured_error_not_found() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:27501";
+    let ke = unique_ke("structured_error");
+
+    let server_session = listening_session(ENDPOINT).await;
+    let client_session = connecting_session(ENDPOINT).await;
+
+    let _server = ztimeout!(ServiceServer::builder(&server_session, ke.as_str()).method_fn(
+        "find_user",
+        |_query| {
+            Box::pin(async {
+                Err(ServiceError::NotFound {
+                    message: "user not found".to_string(),
+                })
+            })
+        },
+    ))
+    .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = ServiceClient::new(&client_session, &ke, Duration::from_secs(5))
+        .expect("client should build");
+
+    let result = client
+        .call_raw("find_user", ZBytes::default(), None)
+        .await;
+
+    match result {
+        Err(ServiceError::NotFound { message }) => {
+            assert_eq!(message, "user not found");
+        }
+        other => panic!("expected NotFound error, got {other:?}"),
+    }
+
+    ztimeout!(server_session.close()).unwrap();
+    ztimeout!(client_session.close()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 3. Method not found
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn method_not_found() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:27502";
+    let ke = unique_ke("method_not_found");
+
+    let server_session = listening_session(ENDPOINT).await;
+    let client_session = connecting_session(ENDPOINT).await;
+
+    let _server = ztimeout!(ServiceServer::builder(&server_session, ke.as_str()).method_fn(
+        "exists",
+        |_query| { Box::pin(async { Ok(ZBytes::default()) }) },
+    ))
+    .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = ServiceClient::new(&client_session, &ke, Duration::from_secs(5))
+        .expect("client should build");
+
+    let result = client
+        .call_raw("nonexistent", ZBytes::default(), None)
+        .await;
+
+    match result {
+        Err(ServiceError::MethodNotFound { method }) => {
+            assert_eq!(method, "nonexistent");
+        }
+        other => panic!("expected MethodNotFound error, got {other:?}"),
+    }
+
+    ztimeout!(server_session.close()).unwrap();
+    ztimeout!(client_session.close()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 4. Invalid request payload — server continues serving after bad request
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invalid_request_no_poison() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:27503";
+    let ke = unique_ke("invalid_request");
+
+    let server_session = listening_session(ENDPOINT).await;
+    let client_session = connecting_session(ENDPOINT).await;
+
+    let _server = ztimeout!(ServiceServer::builder(&server_session, ke.as_str()).method_fn(
+        "greet",
+        |query| {
+            Box::pin(async move {
+                let req: GreetRequest = query
+                    .payload()
+                    .map(z_deserialize)
+                    .transpose()
+                    .map_err(|_| ServiceError::InvalidRequest {
+                        message: "failed to deserialize GreetRequest".to_string(),
+                    })?
+                    .ok_or_else(|| ServiceError::InvalidRequest {
+                        message: "missing request payload".to_string(),
+                    })?;
+                let resp = GreetResponse {
+                    message: format!("Hello, {}!", req.name),
+                };
+                Ok(z_serialize(&resp))
+            })
+        },
+    ))
+    .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = ServiceClient::new(&client_session, &ke, Duration::from_secs(5))
+        .expect("client should build");
+
+    // Send garbage bytes — handler should fail with InvalidRequest
+    let garbage = ZBytes::from(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    let result = client.call_raw("greet", garbage, None).await;
+
+    match result {
+        Err(ServiceError::InvalidRequest { message }) => {
+            assert!(
+                message.contains("deserialize"),
+                "expected deserialization error message, got: {message}"
+            );
+        }
+        other => panic!("expected InvalidRequest error, got {other:?}"),
+    }
+
+    // Now send a valid request — server must NOT be poisoned
+    let valid_resp: GreetResponse = client
+        .call(
+            "greet",
+            &GreetRequest {
+                name: "After-Error".to_string(),
+            },
+            None,
+        )
+        .await
+        .expect("valid call after bad request should succeed");
+    assert_eq!(valid_resp.message, "Hello, After-Error!");
+
+    ztimeout!(server_session.close()).unwrap();
+    ztimeout!(client_session.close()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 5. Deadline exceeded
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn deadline_exceeded() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:27504";
+    let ke = unique_ke("deadline_exceeded");
+
+    let server_session = listening_session(ENDPOINT).await;
+    let client_session = connecting_session(ENDPOINT).await;
+
+    let _server = ztimeout!(ServiceServer::builder(&server_session, ke.as_str()).method_fn(
+        "slow",
+        |_query| {
+            Box::pin(async {
+                // Sleep for 2 seconds — longer than the client timeout
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                let resp = GreetResponse {
+                    message: "too late".to_string(),
+                };
+                Ok(z_serialize(&resp))
+            })
+        },
+    ))
+    .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = ServiceClient::new(&client_session, &ke, Duration::from_secs(5))
+        .expect("client should build");
+
+    // Call with 500ms timeout — server sleeps 2s, so this should fail
+    let result = client
+        .call_raw(
+            "slow",
+            ZBytes::default(),
+            Some(Duration::from_millis(500)),
+        )
+        .await;
+
+    // The client timeout fires at 500ms. The server handler sleeps for 2s.
+    // The client should receive an error — either:
+    // - ServiceError::Internal (from the flume recv timeout / channel close)
+    // - ServiceError::DeadlineExceeded (if the server checks deadline before replying)
+    // Either is acceptable — the key is that we get an error, not a success.
+    assert!(
+        result.is_err(),
+        "expected error from deadline exceeded, got Ok({:?})",
+        result.unwrap().to_bytes()
+    );
+
+    ztimeout!(server_session.close()).unwrap();
+    ztimeout!(client_session.close()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 6. Service discovery: available after start, unavailable after drop
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn discovery_available_then_unavailable() {
+    zenoh_util::init_log_from_env_or("error");
+
+    const ENDPOINT: &str = "tcp/localhost:27505";
+    let ke = unique_ke("discovery");
+
+    let server_session = listening_session(ENDPOINT).await;
+    let client_session = connecting_session(ENDPOINT).await;
+
+    let client = ServiceClient::new(&client_session, &ke, Duration::from_secs(5))
+        .expect("client should build");
+
+    // Before server starts, should not be available
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let available_before = ztimeout!(client.is_available()).expect("is_available should work");
+    assert!(
+        !available_before,
+        "service should NOT be available before server starts"
+    );
+
+    // Start the server
+    let server = ztimeout!(ServiceServer::builder(&server_session, ke.as_str()).method_fn(
+        "ping",
+        |_query| { Box::pin(async { Ok(ZBytes::from(b"pong".as_ref())) }) },
+    ))
+    .expect("server should start");
+
+    // Allow liveliness token to propagate
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let available_after_start =
+        ztimeout!(client.is_available()).expect("is_available should work");
+    assert!(
+        available_after_start,
+        "service should be available after server starts"
+    );
+
+    // Drop server — liveliness token is undeclared
+    drop(server);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let available_after_drop =
+        ztimeout!(client.is_available()).expect("is_available should work");
+    assert!(
+        !available_after_drop,
+        "service should NOT be available after server is dropped"
+    );
+
+    ztimeout!(server_session.close()).unwrap();
+    ztimeout!(client_session.close()).unwrap();
+}

--- a/zenoh-rpc/tests/rpc_server.rs
+++ b/zenoh-rpc/tests/rpc_server.rs
@@ -1,0 +1,307 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use zenoh::bytes::ZBytes;
+
+use zenoh_ext::{z_deserialize, z_serialize};
+use zenoh_rpc::{MethodHandler, ServiceError, ServiceServer, StatusCode, METHOD_ATTACHMENT_KEY};
+
+/// Build a method attachment containing the given method name.
+fn method_attachment(method: &str) -> ZBytes {
+    let map: HashMap<String, String> =
+        HashMap::from([(METHOD_ATTACHMENT_KEY.to_string(), method.to_string())]);
+    z_serialize(&map)
+}
+
+/// Unique key expression generator to avoid cross-test interference.
+fn unique_ke(suffix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("test/rpc/server/{id}/{suffix}")
+}
+
+// -- Test: build a ServiceServer with 2 methods, verify it starts without error --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn service_server_starts_with_two_methods() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("starts");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong".as_ref())) })
+        })
+        .method_fn("echo", |query| {
+            let payload = query
+                .payload()
+                .map(|p| p.to_bytes().to_vec())
+                .unwrap_or_default();
+            Box::pin(async move { Ok(ZBytes::from(payload)) })
+        })
+        .await
+        .expect("server should start without error");
+}
+
+// -- Test: query with correct method name dispatches to the right handler --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispatch_to_correct_handler() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("dispatch");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("get_config", |_query| {
+            Box::pin(async { Ok(z_serialize(&"config_value".to_string())) })
+        })
+        .method_fn("get_status", |_query| {
+            Box::pin(async { Ok(z_serialize(&"running".to_string())) })
+        })
+        .await
+        .expect("server should start");
+
+    // Give the queryable time to register
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Query get_config
+    let replies = session
+        .get(&ke)
+        .attachment(method_attachment("get_config"))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let sample = reply.into_result().expect("reply should be Ok");
+    let value: String = z_deserialize(sample.payload()).expect("deserialize response");
+    assert_eq!(value, "config_value");
+
+    // Query get_status
+    let replies = session
+        .get(&ke)
+        .attachment(method_attachment("get_status"))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let sample = reply.into_result().expect("reply should be Ok");
+    let value: String = z_deserialize(sample.payload()).expect("deserialize response");
+    assert_eq!(value, "running");
+}
+
+// -- Test: query with missing method attachment yields ServiceError::InvalidRequest --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_method_attachment_returns_invalid_request() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("missing_method");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("noop", |_query| Box::pin(async { Ok(ZBytes::default()) }))
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Query without any attachment
+    let replies = session.get(&ke).await.unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let reply_err = reply.into_result().expect_err("should be an error reply");
+    let err: ServiceError =
+        z_deserialize(reply_err.payload()).expect("deserialize ServiceError");
+    assert_eq!(
+        err,
+        ServiceError::InvalidRequest {
+            message: "missing rpc:method attachment".to_string()
+        }
+    );
+    assert_eq!(err.status_code(), StatusCode::InvalidRequest);
+}
+
+// -- Test: query with unknown method yields ServiceError::MethodNotFound --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_method_returns_method_not_found() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("unknown_method");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("known", |_query| Box::pin(async { Ok(ZBytes::default()) }))
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let replies = session
+        .get(&ke)
+        .attachment(method_attachment("nonexistent"))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let reply_err = reply.into_result().expect_err("should be an error reply");
+    let err: ServiceError =
+        z_deserialize(reply_err.payload()).expect("deserialize ServiceError");
+    assert_eq!(
+        err,
+        ServiceError::MethodNotFound {
+            method: "nonexistent".to_string()
+        }
+    );
+    assert_eq!(err.status_code(), StatusCode::MethodNotFound);
+}
+
+// -- Test: handler that returns an error produces the correct error reply --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handler_error_is_propagated() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("handler_error");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("fail", |_query| {
+            Box::pin(async {
+                Err(ServiceError::Internal {
+                    message: "something broke".to_string(),
+                })
+            })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let replies = session
+        .get(&ke)
+        .attachment(method_attachment("fail"))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let reply_err = reply.into_result().expect_err("should be an error reply");
+    let err: ServiceError =
+        z_deserialize(reply_err.payload()).expect("deserialize ServiceError");
+    assert_eq!(
+        err,
+        ServiceError::Internal {
+            message: "something broke".to_string()
+        }
+    );
+}
+
+// -- Test: success reply carries status code Ok in attachment --
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn success_reply_has_ok_status_attachment() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("status_ok");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method_fn("ping", |_query| {
+            Box::pin(async { Ok(ZBytes::from(b"pong".as_ref())) })
+        })
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let replies = session
+        .get(&ke)
+        .attachment(method_attachment("ping"))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let sample = reply.into_result().expect("reply should be Ok");
+
+    // Check the status code attachment
+    let attachment = sample.attachment().expect("reply should have an attachment");
+    let map: HashMap<String, String> =
+        z_deserialize(attachment).expect("deserialize attachment map");
+    let status_str = map
+        .get("rpc:status")
+        .expect("should have rpc:status key");
+    assert_eq!(status_str, "0", "status code should be Ok (0)");
+}
+
+// -- Test: struct implementing MethodHandler works --
+
+struct EchoHandler;
+
+#[async_trait::async_trait]
+impl MethodHandler for EchoHandler {
+    async fn handle(&self, query: &zenoh::query::Query) -> Result<ZBytes, ServiceError> {
+        let payload = query
+            .payload()
+            .map(|p| p.to_bytes().to_vec())
+            .unwrap_or_default();
+        Ok(ZBytes::from(payload))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn struct_method_handler_works() {
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = unique_ke("struct_handler");
+
+    let _server = ServiceServer::builder(&session, ke.as_str())
+        .method("echo", EchoHandler)
+        .await
+        .expect("server should start");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let request_data = b"hello world";
+    let replies = session
+        .get(&ke)
+        .payload(ZBytes::from(request_data.as_ref()))
+        .attachment(method_attachment("echo"))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(5), replies.recv_async())
+        .await
+        .expect("timeout waiting for reply")
+        .expect("channel closed");
+
+    let sample = reply.into_result().expect("reply should be Ok");
+    assert_eq!(sample.payload().to_bytes().as_ref(), request_data);
+}


### PR DESCRIPTION
## Summary
- Port 5 integration test files from zenoh-ext to zenoh-rpc (#113)
- Add 4 standalone usage examples (#114)

## Changes — Tests (#113)
- `zenoh-rpc/tests/rpc.rs` — 16 tests: ServiceError round-trips, StatusCode, Display, ZBytes, DeadlineContext, deadline_attachment
- `zenoh-rpc/tests/rpc_client.rs` — 8 tests: typed/raw calls, nonexistent method, deadline, timeout, error propagation
- `zenoh-rpc/tests/rpc_server.rs` — 7 tests: dispatch, missing/unknown method, handler error, status attachment, struct handler
- `zenoh-rpc/tests/rpc_discovery.rs` — 4 tests: available/unavailable, multi-instance, drop lifecycle
- `zenoh-rpc/tests/rpc_e2e.rs` — 6 tests: happy path, structured errors, method not found, state safety, deadline exceeded, discovery lifecycle

Import rewrites: RPC types from `zenoh_rpc`, serialization from `zenoh_ext`. Removed `#![cfg(feature = "unstable")]` gates.

## Changes — Examples (#114)
- `zenoh-rpc/examples/rpc_server.rs` — multi-method server (greet + add) with input validation
- `zenoh-rpc/examples/rpc_client.rs` — typed/raw calls with error handling
- `zenoh-rpc/examples/rpc_discovery.rs` — liveliness discovery and instance counting
- `zenoh-rpc/examples/rpc_deadline.rs` — deadline propagation and budget checking

README updated with examples table and run instructions.

## Testing
- 66 tests pass: 25 unit + 41 integration
- Examples compile cleanly
- Clippy clean

Closes #113
Closes #114

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->