### PR TITLE
fix: verify encoding in TypedSubscriber before deserializing

### DIFF
--- a/zenoh-ext/src/typed.rs
+++ b/zenoh-ext/src/typed.rs
@@ -147,6 +147,21 @@ fn check_schema_version(
     Ok(())
 }
 
+/// Check that a sample's encoding matches the expected typed encoding.
+/// Returns `Ok(())` if the encoding matches `zenoh-ext/typed:{schema_name}`.
+/// Returns `Err(TypedReceiveError::EncodingMismatch)` if it does not match.
+fn check_encoding(sample: &Sample, schema_name: &str) -> Result<(), TypedReceiveError> {
+    let expected = Encoding::from(format!("zenoh-ext/typed:{}", schema_name));
+    let received = sample.encoding();
+    if *received != expected {
+        return Err(TypedReceiveError::EncodingMismatch {
+            expected: expected.to_string(),
+            received: received.to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// A publisher that only accepts payloads of type `T`.
 ///
 /// Wraps a [`Publisher`] and serializes `T` via [`ZSerializer`](crate::ZSerializer)
@@ -515,21 +530,6 @@ pub trait TypedSessionExt {
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<Error>;
-}
-
-/// Check that a sample's encoding matches the expected typed encoding.
-/// Returns `Ok(())` if the encoding matches `zenoh-ext/typed:{schema_name}`.
-/// Returns `Err(TypedReceiveError::EncodingMismatch)` if it does not match.
-fn check_encoding(sample: &Sample, schema_name: &str) -> Result<(), TypedReceiveError> {
-    let expected = Encoding::from(format!("zenoh-ext/typed:{}", schema_name));
-    let received = sample.encoding();
-    if *received != expected {
-        return Err(TypedReceiveError::EncodingMismatch {
-            expected: expected.to_string(),
-            received: received.to_string(),
-        });
-    }
-    Ok(())
 }
 
 impl TypedSessionExt for Session {

--- a/zenoh-ext/src/typed.rs
+++ b/zenoh-ext/src/typed.rs
@@ -60,9 +60,11 @@ pub trait TypedSchema {
     const SCHEMA_NAME: &'static str;
 }
 
-/// Error type for typed receive operations that include version checking.
+/// Error type for typed receive operations that include encoding and version checking.
 #[derive(Debug)]
 pub enum TypedReceiveError {
+    /// The sample's encoding doesn't match the expected `zenoh-ext/typed:{SCHEMA_NAME}`.
+    EncodingMismatch { expected: String, received: String },
     /// The publisher's schema version doesn't match the subscriber's expected version.
     VersionMismatch {
         expected: u32,
@@ -76,6 +78,10 @@ pub enum TypedReceiveError {
 impl std::fmt::Display for TypedReceiveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::EncodingMismatch { expected, received } => write!(
+                f,
+                "encoding mismatch: expected {expected}, received {received}"
+            ),
             Self::VersionMismatch {
                 expected,
                 received,
@@ -206,6 +212,7 @@ impl<T: Deserialize + TypedSchema> TypedSubscriber<T, FifoChannelHandler<Sample>
 
 impl<T: Deserialize + TypedSchema, Handler> TypedSubscriber<T, Handler> {
     fn deserialize_sample(&self, sample: &Sample) -> Result<T, TypedReceiveError> {
+        check_encoding(sample, T::SCHEMA_NAME)?;
         check_schema_version(sample, self.schema_version, T::SCHEMA_NAME)?;
         z_deserialize::<T>(sample.payload()).map_err(TypedReceiveError::from)
     }
@@ -510,6 +517,21 @@ pub trait TypedSessionExt {
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<Error>;
 }
 
+/// Check that a sample's encoding matches the expected typed encoding.
+/// Returns `Ok(())` if the encoding matches `zenoh-ext/typed:{schema_name}`.
+/// Returns `Err(TypedReceiveError::EncodingMismatch)` if it does not match.
+fn check_encoding(sample: &Sample, schema_name: &str) -> Result<(), TypedReceiveError> {
+    let expected = Encoding::from(format!("zenoh-ext/typed:{}", schema_name));
+    let received = sample.encoding();
+    if *received != expected {
+        return Err(TypedReceiveError::EncodingMismatch {
+            expected: expected.to_string(),
+            received: received.to_string(),
+        });
+    }
+    Ok(())
+}
+
 impl TypedSessionExt for Session {
     fn declare_typed_publisher<'b, T: Serialize + TypedSchema, TryIntoKeyExpr>(
         &self,
@@ -586,5 +608,114 @@ impl TypedSessionExt for Session {
             Ok(replies)
         })();
         TypedGetFuture { result }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zenoh::key_expr::KeyExpr;
+    use zenoh::sample::SampleBuilder;
+
+    fn make_sample_with_encoding(encoding: &str) -> Sample {
+        let payload = z_serialize(&42u32);
+        let key: KeyExpr<'static> = KeyExpr::try_from("test/key").unwrap();
+        SampleBuilder::put(key, payload)
+            .encoding(Encoding::from(encoding))
+            .into()
+    }
+
+    fn make_sample_default_encoding() -> Sample {
+        let payload = z_serialize(&42u32);
+        let key: KeyExpr<'static> = KeyExpr::try_from("test/key").unwrap();
+        SampleBuilder::put(key, payload).into()
+    }
+
+    #[test]
+    fn check_encoding_accepts_correct_typed_encoding() {
+        let sample = make_sample_with_encoding("zenoh-ext/typed:test-payload");
+        assert!(check_encoding(&sample, "test-payload").is_ok());
+    }
+
+    #[test]
+    fn check_encoding_rejects_wrong_typed_encoding() {
+        let sample = make_sample_with_encoding("zenoh-ext/typed:other-type");
+        let result = check_encoding(&sample, "test-payload");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TypedReceiveError::EncodingMismatch { expected, received } => {
+                assert!(
+                    expected.contains("test-payload"),
+                    "expected should contain schema name, got: {expected}"
+                );
+                assert!(
+                    received.contains("other-type"),
+                    "received should contain actual schema name, got: {received}"
+                );
+            }
+            other => panic!("expected EncodingMismatch, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_encoding_rejects_untyped_encoding() {
+        let sample = make_sample_with_encoding("application/json");
+        let result = check_encoding(&sample, "test-payload");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TypedReceiveError::EncodingMismatch { expected, received } => {
+                assert!(
+                    expected.contains("test-payload"),
+                    "expected should reference schema name, got: {expected}"
+                );
+                assert!(
+                    received.contains("application/json"),
+                    "received should show actual encoding, got: {received}"
+                );
+            }
+            other => panic!("expected EncodingMismatch, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_encoding_rejects_default_encoding() {
+        let sample = make_sample_default_encoding();
+        let result = check_encoding(&sample, "test-payload");
+        assert!(
+            result.is_err(),
+            "default encoding should not pass typed encoding check"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                TypedReceiveError::EncodingMismatch { .. }
+            ),
+            "should be EncodingMismatch variant"
+        );
+    }
+
+    #[test]
+    fn encoding_mismatch_display_distinguishes_from_deserialization_error() {
+        let encoding_err = TypedReceiveError::EncodingMismatch {
+            expected: "zenoh-ext/typed:foo".to_string(),
+            received: "application/json".to_string(),
+        };
+        let deser_err = TypedReceiveError::DeserializationFailed(ZDeserializeError);
+
+        let encoding_msg = encoding_err.to_string();
+        let deser_msg = deser_err.to_string();
+
+        assert!(
+            encoding_msg.contains("encoding mismatch"),
+            "encoding error should say 'encoding mismatch', got: {encoding_msg}"
+        );
+        assert!(
+            deser_msg.contains("deserialization"),
+            "deser error should mention 'deserialization', got: {deser_msg}"
+        );
+        assert_ne!(
+            encoding_msg, deser_msg,
+            "error messages should be distinguishable"
+        );
     }
 }

--- a/zenoh-ext/tests/typed.rs
+++ b/zenoh-ext/tests/typed.rs
@@ -85,7 +85,7 @@ async fn typed_pub_sub_round_trip() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn typed_subscriber_malformed_payload_yields_err() {
+async fn typed_subscriber_untyped_publisher_yields_encoding_mismatch() {
     use zenoh_ext::TypedSessionExt;
 
     let session = zenoh::open(zenoh::Config::default()).await.unwrap();
@@ -97,7 +97,7 @@ async fn typed_subscriber_malformed_payload_yields_err() {
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Publish raw garbage bytes using a normal publisher
+    // Publish raw garbage bytes using a normal (untyped) publisher
     let raw_publisher = session
         .declare_publisher("test/typed/malformed")
         .await
@@ -109,8 +109,21 @@ async fn typed_subscriber_malformed_payload_yields_err() {
         .expect("timeout waiting for message")
         .expect("channel closed");
 
-    // Should be an Err, not a panic
-    assert!(received.is_err());
+    // Untyped publisher has wrong encoding — should be EncodingMismatch, not DeserializationFailed
+    match received {
+        Err(zenoh_ext::TypedReceiveError::EncodingMismatch { expected, received }) => {
+            assert!(
+                expected.contains("telemetry-payload"),
+                "expected should reference schema name, got: {expected}"
+            );
+            assert!(
+                !received.contains("telemetry-payload"),
+                "received should NOT match the typed encoding, got: {received}"
+            );
+        }
+        Err(other) => panic!("expected EncodingMismatch, got: {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
- TypedSubscriber now checks `sample.encoding()` against `zenoh-ext/typed:{SCHEMA_NAME}` before deserializing
- Adds `EncodingMismatch` variant to `TypedReceiveError` with expected/received encoding strings
- Error messages distinguish "wrong type" (encoding mismatch) from "malformed payload" (deserialization failure)

## Changes
- `check_encoding()` function validates encoding before deserialization in `deserialize_sample()`
- `TypedReceiveError::EncodingMismatch { expected, received }` variant added
- Display impl distinguishes encoding mismatch from deserialization errors
- 5 unit tests covering correct encoding, wrong typed encoding, untyped encoding, default encoding, and error message distinction

## Testing
- All 5 new unit tests pass
- All 21 integration tests pass (including backward-compat test from #102)
- Clippy clean with `-D warnings`
- `cargo fmt --check` passes

Closes #129

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->